### PR TITLE
Affine / Interpolated Operators

### DIFF
--- a/src/rom_operator_inference/core/nonparametric/_public.py
+++ b/src/rom_operator_inference/core/nonparametric/_public.py
@@ -147,7 +147,7 @@ class DiscreteOpInfROM(_NonparametricOpInfROM):
 
     # TODO: convenience method for dealing with multiple trajectories (bursts).
     # @staticmethod
-    # def stack_training_states(statelist):
+    # def stack_training_bursts(statelist):
     #     """Translate a collection of state trajectories to
     #     (states, nextstates) arrays that are appropriate arguments for fit().
     #

--- a/src/rom_operator_inference/core/operators/__init__.py
+++ b/src/rom_operator_inference/core/operators/__init__.py
@@ -2,15 +2,26 @@
 """Operator classes for the individual components of polynomial models.
 
 That is, for models with the form
-    dq / dt = c + Aq(t) + H[q(t) ⊗ q(t)] + G[q(t) ⊗ q(t) ⊗ q(t)],
+    dq / dt = c + Aq(t) + H[q(t) ⊗ q(t)] + G[q(t) ⊗ q(t) ⊗ q(t)] + Bu(t),
 these classes represent the operators c (constant), A (linear), H (quadratic),
-and G (cubic).
+G (cubic), and B (input).
 
-Classes
--------
-*
+Nonparametric Operator Classes
+------------------------------
+* ConstantOperator: constant operators (c)
+* LinearOperator: linear operators for state and input (A, B)
+* QuadraticOperator: quadratic operators (H)
+* CubicOperator: quadratic operators (G)
+
+Parametric Operators: 1D Cubic Spline Intepolation
+--------------------------------------------------
+TODO
+
+Parametric Operators: Affine Expansion
+--------------------------------------
+TODO
 """
 
 from ._nonparametric import *
-# from ._affine import *
-# from ._interpolate import *
+from ._affine import *
+from ._interpolate import *

--- a/src/rom_operator_inference/core/operators/__init__.py
+++ b/src/rom_operator_inference/core/operators/__init__.py
@@ -7,19 +7,47 @@ these classes represent the operators c (constant), A (linear), H (quadratic),
 G (cubic), and B (input).
 
 Nonparametric Operator Classes
-------------------------------
+==============================
+These classes represent operators that do not depend on external parameters.
 * ConstantOperator: constant operators (c)
 * LinearOperator: linear operators for state and input (A, B)
 * QuadraticOperator: quadratic operators (H)
 * CubicOperator: quadratic operators (G)
+Used by [Discrete|Continuous]OpInfROM.
 
-Parametric Operators: 1D Cubic Spline Intepolation
---------------------------------------------------
-TODO
+The remaining classes are for operators that depend on a external parameters,
+i.e., A = A(µ). There are several parameterization strategies.
 
-Parametric Operators: Affine Expansion
---------------------------------------
-TODO
+Interpolated Operator Classes
+=============================
+These classes handle the parametric dependence of an operator A = A(µ)
+with elementwise interpolation between known operator matrices, i.e.,
+    A(µ)[i,j] = Interpolator([µ1, µ2, ...], [A1[i,j], A2[i,j], ...])(µ),
+where µ1, µ2, ... are parameter values and A1, A2, ... are the corresponding
+operator matrices, e.g., A1 = A(µ1).
+There are different sets of classes for each kind of interpolation strategy.
+
+1D Cubic Spline Intepolation
+----------------------------
+These classes use scipy.interpolate.CubicSpline to do one-dimensional entrywise
+interpolation of the operator entries. The parameters µ must be scalars.
+* Spline1dConstantOperator: constant operators c(µ).
+* Spline1dLinearOperator: linear operators for state and input, A(µ) and B(µ).
+* Spline1dQuadraticOperator: quadratic operators H(µ).
+* Spline1dCubicOperator: quadratic operators G(µ).
+Used by Spline1d[Discrete|Continuous]OpInfROM.
+
+Affine Operator Classes
+=======================
+These operators assume the parametric dependence of an operator A = A(µ) has a
+known "affine" structure,
+    A(µ) = sum_{i=1}^{nterms} θ_{i}(µ) * A_{i},
+where θ_{i} are scalar-valued functions and A_{i} are matrices.
+* AffineConstantOperator: constant operators c(µ).
+* AffineLinearOperator: linear operators for state and input, A(µ) and B(µ).
+* AffineQuadraticOperator: quadratic operators H(µ).
+* AffineCubicOperator: quadratic operators G(µ).
+Used by Affine[Discrete|Continuous]OpInfROM.
 """
 
 from ._nonparametric import *

--- a/src/rom_operator_inference/core/operators/_affine.py
+++ b/src/rom_operator_inference/core/operators/_affine.py
@@ -14,8 +14,8 @@ __all__ = [
 
 import numpy as np
 
-from ._nonparametric import (_BaseParametricOperator,
-                             ConstantOperator,
+from ._base import _BaseParametricOperator
+from ._nonparametric import (ConstantOperator,
                              LinearOperator,
                              QuadraticOperator,
                              # CrossQuadraticOperator,
@@ -52,7 +52,8 @@ class _AffineOperator(_BaseParametricOperator):
 
         # Ensure that the coefficient functions are callable.
         if any(not callable(theta) for theta in coefficient_functions):
-            raise TypeError("coefficients of affine operator must be callable")
+            raise TypeError("coefficient functions of affine operator "
+                            "must be callable")
         self.__ceofficient_functions = coefficient_functions
 
         # Check that the right number of terms are included.
@@ -63,7 +64,7 @@ class _AffineOperator(_BaseParametricOperator):
                              f"!= len(matrices) = {n_matrices}")
 
         # Check that each matrix in the list has the same shape.
-        self._check_shape_consistency(matrices)
+        self._check_shape_consistency(matrices, "operator matrix")
         self.__matrices = matrices
 
     @property
@@ -119,9 +120,9 @@ class _AffineOperator(_BaseParametricOperator):
         """
         if not isinstance(other, self.__class__):
             return False
-        if self.OperatorClass is not other.OperatorClass:
-            return False
         if len(self) != len(other):
+            return False
+        if self.shape != other.shape:
             return False
         return all(np.all(left == right)
                    for left, right in zip(self.matrices, other.matrices))

--- a/src/rom_operator_inference/core/operators/_affine.py
+++ b/src/rom_operator_inference/core/operators/_affine.py
@@ -38,7 +38,7 @@ class _AffineOperator(_BaseParametricOperator):
         Operator matrices in each term of the affine expansion (A_{i}'s).
     """
     def __init__(self, coefficient_functions, matrices):
-        """Save the coefficient functions and component matrices.
+        """Save the coefficient functions and operator matrices.
 
         Parameters
         ----------
@@ -54,7 +54,7 @@ class _AffineOperator(_BaseParametricOperator):
         if any(not callable(theta) for theta in coefficient_functions):
             raise TypeError("coefficient functions of affine operator "
                             "must be callable")
-        self.__ceofficient_functions = coefficient_functions
+        self.__coefficient_functions = coefficient_functions
 
         # Check that the right number of terms are included.
         # if (n_coeffs := len(coeffs) != (n_matrices := len(matrices)):
@@ -70,7 +70,7 @@ class _AffineOperator(_BaseParametricOperator):
     @property
     def coefficient_functions(self):
         """Coefficient scalar-valued functions in the affine expansion."""
-        return self.__ceofficient_functions
+        return self.__coefficient_functions
 
     @property
     def matrices(self):
@@ -79,7 +79,7 @@ class _AffineOperator(_BaseParametricOperator):
 
     @property
     def shape(self):
-        """Shape: the shape of the component matrices."""
+        """Shape: the shape of the operator matrices."""
         return self.matrices[0].shape
 
     @staticmethod
@@ -129,7 +129,7 @@ class _AffineOperator(_BaseParametricOperator):
 
 
 class AffineConstantOperator(_AffineOperator):
-    """Constant operator with affine structure, i.e.,
+    """Constant operator with affine parametric structure, i.e.,
 
         c(µ) = sum_{i=1}^{nterms} θ_{i}(µ) * c_{i}.
 
@@ -147,7 +147,7 @@ class AffineConstantOperator(_AffineOperator):
 
 
 class AffineLinearOperator(_AffineOperator):
-    """Linear operator with affine structure, i.e.,
+    """Linear operator with affine parametric structure, i.e.,
 
         A(µ) = sum_{i=1}^{nterms} θ_{i}(µ) * A_{i}.
 
@@ -165,7 +165,7 @@ class AffineLinearOperator(_AffineOperator):
 
 
 class AffineQuadraticOperator(_AffineOperator):
-    """Quadratic operator with affine structure, i.e.,
+    """Quadratic operator with affine parametric structure, i.e.,
 
         H(µ) = sum_{i=1}^{nterms} θ_{i}(µ) * H_{i}.
 
@@ -183,7 +183,7 @@ class AffineQuadraticOperator(_AffineOperator):
 
 
 class AffineCubicOperator(_AffineOperator):
-    """Cubic operator with affine structure, i.e.,
+    """Cubic operator with affine parametric structure, i.e.,
 
         G(µ) = sum_{i=1}^{nterms} θ_{i}(µ) * G_{i}.
 

--- a/src/rom_operator_inference/core/operators/_affine.py
+++ b/src/rom_operator_inference/core/operators/_affine.py
@@ -1,4 +1,8 @@
 # core/operators/_affine.py
+"""Classes for operators that depend affinely on external parameters, i.e.,
+
+    A(µ) = sum_{i=1}^{nterms} θ_{i}(µ) * A_{i}.
+"""
 
 __all__ = [
     "AffineConstantOperator",
@@ -8,120 +12,114 @@ __all__ = [
     "AffineCubicOperator",
 ]
 
-import abc
 import numpy as np
 
-from ._nonparametric import (_BaseNonparametricOperator,
-                             ConstantOperator, LinearOperator,
-                             QuadraticOperator, CubicOperator)
+from ._nonparametric import (_BaseParametricOperator,
+                             ConstantOperator,
+                             LinearOperator,
+                             QuadraticOperator,
+                             # CrossQuadraticOperator,
+                             CubicOperator)
 
 
-# TODO: symbol (for printing)
-class _BaseAffineOperator(abc.ABC):
-    """Base class for representing operators with affine structure, i.e.,
+class _AffineOperator(_BaseParametricOperator):
+    """Base class for parametric operators with affine structure, i.e.,
 
         A(µ) = sum_{i=1}^{nterms} θ_{i}(µ) * A_{i}.
 
-    The matrix A(µ) is constructed by calling the object once the coefficient
-    functions and component matrices are set.
+    The matrix A(µ) for a given µ is constructed by calling the object.
 
     Attributes
     ----------
     coefficient_functions : list of `nterms` callables
-        Coefficient scalar-valued functions in the affine expansion.
-        Each must take the same sized input and return a scalar.
+        Scalar-valued coefficient functions in each term of the affine
+        expansion (θ_{i}'s).
     matrices : list of `nterms` ndarrays, all of the same shape
-        Component matrices in each term of the affine expansion.
+        Operator matrices in each term of the affine expansion (A_{i}'s).
     """
-    @abc.abstractmethod
-    def __init__(self, OperatorClass, coeffs, matrices, **kwargs):
+    def __init__(self, coefficient_functions, matrices):
         """Save the coefficient functions and component matrices.
 
         Parameters
         ----------
-        OperatorClass : class
-            Class of operator to construct, a subclass of
-            core.operators._BaseNonparametricOperator.
-        coeffs : list of `nterms` callables
-            Coefficient scalar-valued functions in the affine expansion.
-            Each must take the same sized input and return a scalar.
+        coefficient_functions : list of `nterms` callables
+            Scalar-valued coefficient functions in each term of the affine
+            expansion (θ_{i}'s).
         matrices : list of `nterms` ndarrays, all of the same shape
-            Component matrices in each term of the affine expansion.
+            Operator matrices in each term of the affine expansion (A_{i}'s).
         """
-        if not issubclass(OperatorClass, _BaseNonparametricOperator):
-            raise TypeError(f"invalid operatortype '{OperatorClass.__name__}'")
-        self.__opclass = OperatorClass
+        _BaseParametricOperator.__init__(self)
 
-        if any(not callable(theta) for theta in coeffs):
+        # Ensure that the coefficient functions are callable.
+        if any(not callable(theta) for theta in coefficient_functions):
             raise TypeError("coefficients of affine operator must be callable")
-        self.__thetas = coeffs
+        self.__ceofficient_functions = coefficient_functions
 
         # Check that the right number of terms are included.
         # if (n_coeffs := len(coeffs) != (n_matrices := len(matrices)):
-        n_coeffs, n_matrices = len(coeffs), len(matrices)
+        n_coeffs, n_matrices = len(coefficient_functions), len(matrices)
         if n_coeffs != n_matrices:
-            raise ValueError(f"{n_coeffs} = len(coeffs) "
+            raise ValueError(f"{n_coeffs} = len(coefficient_functions) "
                              f"!= len(matrices) = {n_matrices}")
 
         # Check that each matrix in the list has the same shape.
-        shape = matrices[0].shape
-        if any(A.shape != shape for A in matrices):
-            raise ValueError("affine component matrix shapes do not match")
-
+        self._check_shape_consistency(matrices)
         self.__matrices = matrices
-        self.__kwargs = kwargs
 
     @property
     def coefficient_functions(self):
         """Coefficient scalar-valued functions in the affine expansion."""
-        return self.__thetas
+        return self.__ceofficient_functions
 
     @property
     def matrices(self):
         """Component matrices in each term of the affine expansion."""
         return self.__matrices
 
-    # @property
-    # def shape(self):
-    #     """Shape: the shape of the component matrices."""
-    #     return self.matrices[0].shape
+    @property
+    def shape(self):
+        """Shape: the shape of the component matrices."""
+        return self.matrices[0].shape
 
     @staticmethod
-    def validate_coeffs(thetas, mu):
+    def _validate_coefficient_functions(coefficient_functions, parameter):
         """Check that each coefficient function 1) is a callable function,
         2) takes in the right sized inputs, and 3) returns scalar values.
 
         Parameters
         ----------
-        mu : float or (p,) ndarray
-            A test input for the coefficient functions.
+        coefficient_functions : list of `nterms` callables
+            Scalar-valued coefficient functions in each term of the affine
+            expansion (θ_{i}'s).
+        parameter : (p,) ndarray or float (p = 1).
+            Parameter input to use as a test for the coefficient functions (µ).
         """
-        for theta in thetas:
+        for theta in coefficient_functions:
             if not callable(theta):
                 raise TypeError("coefficient functions of affine operator "
                                 "must be callable")
-            elif not np.isscalar(theta(mu)):
+            elif not np.isscalar(theta(parameter)):
                 raise ValueError("coefficient functions of affine operator "
                                  "must return a scalar")
 
-    def __call__(self, mu):
+    def __call__(self, parameter):
         """Evaluate the affine operator at the given parameter."""
-        entries = np.sum([thetai(mu)*Ai for thetai, Ai in zip(
+        entries = np.sum([thetai(parameter)*Ai for thetai, Ai in zip(
                           self.coefficient_functions, self.matrices)],
                          axis=0)
-        return self.__opclass(entries, **self.__kwargs)
+        return self.OperatorClass(entries)
 
     def __len__(self):
         """Length: number of terms in the affine expansion."""
-        return len(self.coefficient_functions)
+        return len(self.matrices)
 
     def __eq__(self, other):
-        """Test whether the component matrices of two AffineOperator objects
+        """Test whether the operator matrices of two AffineOperator objects
         are numerically equal. Coefficient functions are *NOT* compared.
         """
         if not isinstance(other, self.__class__):
             return False
-        if self.__opclass is not other.__opclass:
+        if self.OperatorClass is not other.OperatorClass:
             return False
         if len(self) != len(other):
             return False
@@ -129,121 +127,73 @@ class _BaseAffineOperator(abc.ABC):
                    for left, right in zip(self.matrices, other.matrices))
 
 
-class AffineConstantOperator(_BaseAffineOperator):
+class AffineConstantOperator(_AffineOperator):
     """Constant operator with affine structure, i.e.,
 
         c(µ) = sum_{i=1}^{nterms} θ_{i}(µ) * c_{i}.
 
-    The vector c(µ) is constructed by calling the object once the coefficient
-    functions and component matrices are set.
+    The vector c(µ) for a given µ is constructed by calling the object.
 
     Attributes
     ----------
     coefficient_functions : list of `nterms` callables
-        Coefficient scalar-valued functions in the affine expansion.
-        Each must take the same sized input and return a scalar.
-    vectors : list of `nterms` one-dimensional ndarrays
-        Component vectors in each term of the affine expansion.
+        Scalar-valued coefficient functions in each term of the affine
+        expansion (θ_{i}'s).
+    matrices : list of `nterms` ndarrays, all of the same shape
+        Operator matrices in each term of the affine expansion (c_{i}'s).
     """
-    def __init__(self, coeffs, vectors):
-        """Save the coefficient functions and component vectors.
-
-        Parameters
-        ----------
-        coeffs : list of `nterms` callables
-            Coefficient scalar-valued functions in the affine expansion.
-            Each must take the same sized input and return a scalar.
-        vectors : list of `nterms` one-dimensional ndarrays
-            Component vectors in each term of the affine expansion.
-        """
-        _BaseAffineOperator.__init__(self, ConstantOperator, coeffs, vectors)
+    _OperatorClass = ConstantOperator
 
 
-class AffineLinearOperator(_BaseAffineOperator):
+class AffineLinearOperator(_AffineOperator):
     """Linear operator with affine structure, i.e.,
 
         A(µ) = sum_{i=1}^{nterms} θ_{i}(µ) * A_{i}.
 
-    The matrix A(µ) is constructed by calling the object once the coefficient
-    functions and component matrices are set.
+    The matrix A(µ) for a given µ is constructed by calling the object.
 
     Attributes
     ----------
     coefficient_functions : list of `nterms` callables
-        Coefficient scalar-valued functions in the affine expansion.
-        Each must take the same sized input and return a scalar.
+        Scalar-valued coefficient functions in each term of the affine
+        expansion (θ_{i}'s).
     matrices : list of `nterms` ndarrays, all of the same shape
-        Component matrices in each term of the affine expansion.
+        Operator matrices in each term of the affine expansion (A_{i}'s).
     """
-    def __init__(self, coeffs, matrices):
-        """Save the coefficient functions and component matrices.
-
-        Parameters
-        ----------
-        coeffs : list of `nterms` callables
-            Coefficient scalar-valued functions in the affine expansion.
-            Each must take the same sized input and return a scalar.
-        matrices : list of `nterms` ndarrays, all of the same shape
-            Component matrices in each term of the affine expansion.
-        """
-        _BaseAffineOperator.__init__(self, LinearOperator, coeffs, matrices)
+    _OperatorClass = LinearOperator
 
 
-class AffineQuadraticOperator(_BaseAffineOperator):
+class AffineQuadraticOperator(_AffineOperator):
     """Quadratic operator with affine structure, i.e.,
 
         H(µ) = sum_{i=1}^{nterms} θ_{i}(µ) * H_{i}.
 
-    The matrix H(µ) is constructed by calling the object once the coefficient
-    functions and component matrices are set.
+    The matrix H(µ) for a given µ is constructed by calling the object.
 
     Attributes
     ----------
     coefficient_functions : list of `nterms` callables
-        Coefficient scalar-valued functions in the affine expansion.
-        Each must take the same sized input and return a scalar.
+        Scalar-valued coefficient functions in each term of the affine
+        expansion (θ_{i}'s).
     matrices : list of `nterms` ndarrays, all of the same shape
-        Component matrices in each term of the affine expansion.
+        Operator matrices in each term of the affine expansion (H_{i}'s).
     """
-    def __init__(self, coeffs, matrices):
-        """Save the coefficient functions and component matrices.
-
-        Parameters
-        ----------
-        coeffs : list of `nterms` callables
-            Coefficient scalar-valued functions in the affine expansion.
-            Each must take the same sized input and return a scalar.
-        matrices : list of `nterms` ndarrays, all of the same shape
-            Component matrices in each term of the affine expansion.
-        """
-        _BaseAffineOperator.__init__(self, QuadraticOperator, coeffs, matrices)
+    _OperatorClass = QuadraticOperator
 
 
-class AffineCubicOperator(_BaseAffineOperator):
+class AffineCubicOperator(_AffineOperator):
     """Cubic operator with affine structure, i.e.,
 
         G(µ) = sum_{i=1}^{nterms} θ_{i}(µ) * G_{i}.
 
-    The matrix G(µ) is constructed by calling the object once the coefficient
-    functions and component matrices are set.
+    The matrix G(µ) for a given µ is constructed by calling the object.
 
     Attributes
     ----------
     coefficient_functions : list of `nterms` callables
-        Coefficient scalar-valued functions in the affine expansion.
-        Each must take the same sized input and return a scalar.
+        Scalar-valued coefficient functions in each term of the affine
+        expansion (θ_{i}'s).
     matrices : list of `nterms` ndarrays, all of the same shape
-        Component matrices in each term of the affine expansion.
+        Operator matrices in each term of the affine expansion (G_{i}'s).
     """
-    def __init__(self, coeffs, matrices):
-        """Save the coefficient functions and component matrices.
-
-        Parameters
-        ----------
-        coeffs : list of `nterms` callables
-            Coefficient scalar-valued functions in the affine expansion.
-            Each must take the same sized input and return a scalar.
-        matrices : list of `nterms` ndarrays, all of the same shape
-            Component matrices in each term of the affine expansion.
-        """
-        _BaseAffineOperator.__init__(self, CubicOperator, coeffs, matrices)
+    _OperatorClass = CubicOperator

--- a/src/rom_operator_inference/core/operators/_base.py
+++ b/src/rom_operator_inference/core/operators/_base.py
@@ -1,4 +1,11 @@
 # core/operators/_base.py
+"""Abstract base classes for operators.
+
+Classes
+-------
+* _BaseNonparametricOperator: base for operators without parameter dependence.
+* _BaseParametricOperator: base for operators with parameter dependence.
+"""
 
 __all__ = []
 
@@ -55,6 +62,8 @@ class _BaseNonparametricOperator(abc.ABC):
         """Return True if two Operator objects are numerically equal."""
         if not isinstance(other, self.__class__):
             return False
+        if self.shape != other.shape:
+            return False
         return np.all(self.entries == other.entries)
 
 
@@ -99,8 +108,8 @@ class _BaseParametricOperator(abc.ABC):
         raise NotImplementedError
 
     @staticmethod
-    def _check_shape_consistency(iterable, prefix="component matrix"):
+    def _check_shape_consistency(iterable, prefix="operator matrix"):
         """Ensure that each array in `iterable` has the same shape."""
         shape = np.shape(iterable[0])
         if any(np.shape(A) != shape for A in iterable):
-            raise ValueError(f"{prefix} shapes do not match")
+            raise ValueError(f"{prefix} shapes inconsistent")

--- a/src/rom_operator_inference/core/operators/_base.py
+++ b/src/rom_operator_inference/core/operators/_base.py
@@ -64,16 +64,43 @@ class _BaseParametricOperator(abc.ABC):
     results in a non-parametric operator:
 
     >>> parametric_operator = MyParametricOperator(init_args)
-    >>> nonparametric_operator = parametric_operator(param)
+    >>> nonparametric_operator = parametric_operator(parameter_value)
     >>> isinstance(nonparametric_operator, _BaseNonparametricOperator)
     True
     """
+    # Must be specified by child classes.
+    _OperatorClass = NotImplemented
+
+    @property
+    def OperatorClass(self):
+        """Class of nonparametric operator to represent this parametric
+        operator at a particular parameter, a subclass of
+        core.operators._BaseNonparametricOperator:
+        >>> type(MyParametricOperator(init_args)(parameter_value)).
+        """
+        return self._OperatorClass
+
     @abc.abstractmethod
-    def __init__(self):                                     # pragma: no cover
-        """Set operator entries, affine functions, name, etc."""
-        raise NotImplementedError
+    def __init__(self):
+        """Validate the OperatorClass.
+        Child classes must implement this method, which should set and
+        validate attributes needed to construct the parametric operator.
+        """
+        # Validate the OperatorClass.
+        if not issubclass(self.OperatorClass, _BaseNonparametricOperator):
+            raise RuntimeError("invalid OperatorClass "
+                               f"'{self._OperatorClass.__name__}'")
 
     @abc.abstractmethod
     def __call__(self, parameter):                          # pragma: no cover
-        """Return the nonparametric operator corresponding to the parameter."""
+        """Return the nonparametric operator corresponding to the parameter,
+        of type self.OperatorClass.
+        """
         raise NotImplementedError
+
+    @staticmethod
+    def _check_shape_consistency(iterable, prefix="component matrix"):
+        """Ensure that each array in `iterable` has the same shape."""
+        shape = np.shape(iterable[0])
+        if any(np.shape(A) != shape for A in iterable):
+            raise ValueError(f"{prefix} shapes do not match")

--- a/src/rom_operator_inference/core/operators/_base.py
+++ b/src/rom_operator_inference/core/operators/_base.py
@@ -32,7 +32,12 @@ class _BaseNonparametricOperator(abc.ABC):
 
     @abc.abstractmethod
     def __call__(*args, **kwargs):                          # pragma: no cover
+        """Apply the operator mapping to the given states / inputs."""
         raise NotImplementedError
+
+    def evaluate(self, *args, **kwargs):
+        """Apply the operator mapping to the given states / inputs."""
+        return self(*args, **kwargs)
 
     @staticmethod
     def _validate_entries(entries):

--- a/src/rom_operator_inference/core/operators/_interpolate.py
+++ b/src/rom_operator_inference/core/operators/_interpolate.py
@@ -16,8 +16,8 @@ __all__ = [
 import numpy as np
 import scipy.interpolate
 
-from ._nonparametric import (_BaseParametricOperator,
-                             ConstantOperator,
+from ._base import _BaseParametricOperator
+from ._nonparametric import (ConstantOperator,
                              LinearOperator,
                              QuadraticOperator,
                              # CrossQuadraticOperator,
@@ -120,11 +120,9 @@ class _InterpolatedOperator(_BaseParametricOperator):
         """
         if not isinstance(other, self.__class__):
             return False
-        if self.OperatorClass is not other.OperatorClass:
-            return False
-        if self.InterpolatorClass is not other.InterpolatorClass:
-            return False
         if len(self) != len(other):
+            return False
+        if self.shape != other.shape:
             return False
         if any(not np.all(left == right)
                for left, right in zip(self.parameter_samples,

--- a/src/rom_operator_inference/core/operators/_interpolate.py
+++ b/src/rom_operator_inference/core/operators/_interpolate.py
@@ -36,10 +36,10 @@ class _InterpolatedOperator(_BaseParametricOperator):
 
     Attributes
     ----------
-    parameter_samples : list of `nterms` scalars or ndarrays
+    parameter_values : list of `nterms` scalars or ndarrays
         Parameter values at which the operators matrices are known.
     matrices : list of `nterms` ndarray, all of the same shape.
-        Component matrices corresponding to the `parameter_samples`.
+        Component matrices corresponding to the `parameter_values`.
     OperatorClass : class
         Class of operator to construct, a subclass of
         core.operators._BaseNonparametricOperator.
@@ -56,44 +56,44 @@ class _InterpolatedOperator(_BaseParametricOperator):
         """scipy.interpolate class for the elementwise interpolation."""
         return self._InterpolatorClass
 
-    def __init__(self, parameter_samples, matrices, **kwargs):
+    def __init__(self, parameter_values, matrices, **kwargs):
         """Construct the interpolator.
 
         Parameters
         ----------
-        parameter_samples : list of `nterms` scalars or ndarrays
+        parameter_values : list of `nterms` scalars or ndarrays
             Parameter values at which the operators matrices are known.
         matrices : list of `nterms` ndarray, all of the same shape.
-            Operator entries corresponding to the `parameter_samples`.
+            Operator entries corresponding to the `parameter_values`.
         kwargs
             Additional arguments for the interpolator.
         """
         _BaseParametricOperator.__init__(self)
 
         # Ensure there are the same number of parameter samples and matrices.
-        n_params, n_matrices = len(parameter_samples), len(matrices)
+        n_params, n_matrices = len(parameter_values), len(matrices)
         if n_params != n_matrices:
-            raise ValueError(f"{n_params} = len(parameter_samples) "
+            raise ValueError(f"{n_params} = len(parameter_values) "
                              f"!= len(matrices) = {n_matrices}")
 
         # Ensure parameter / matrix shapes are consistent.
-        self._check_shape_consistency(parameter_samples, "parameter sample")
+        self._check_shape_consistency(parameter_values, "parameter sample")
         self._check_shape_consistency(matrices, "operator matrix")
 
         # Construct the spline.
-        self.__parameter_samples = parameter_samples
+        self.__parameter_values = parameter_values
         self.__matrices = matrices
-        self.__interpolator = self.InterpolatorClass(parameter_samples,
+        self.__interpolator = self.InterpolatorClass(parameter_values,
                                                      matrices, **kwargs)
 
     @property
-    def parameter_samples(self):                            # pragma: no cover
+    def parameter_values(self):                            # pragma: no cover
         """Parameter values at which the operators matrices are known."""
-        return self.__parameter_samples
+        return self.__parameter_values
 
     @property
     def matrices(self):
-        """Operator matrices corresponding to the parameter_samples."""
+        """Operator matrices corresponding to the parameter_values."""
         return self.__matrices
 
     @property
@@ -124,9 +124,12 @@ class _InterpolatedOperator(_BaseParametricOperator):
             return False
         if self.shape != other.shape:
             return False
+        paramshape = np.shape(self.parameter_values[0])
+        if paramshape != np.shape(other.parameter_values[1]):
+            return False
         if any(not np.all(left == right)
-               for left, right in zip(self.parameter_samples,
-                                      other.parameter_samples)):
+               for left, right in zip(self.parameter_values,
+                                      other.parameter_values)):
             return False
         return all(np.all(left == right)
                    for left, right in zip(self.matrices, other.matrices))
@@ -143,10 +146,10 @@ class Spline1dConstantOperator(_InterpolatedOperator):
 
     Attributes
     ----------
-    parameter_samples : list of `nterms` scalars or ndarrays
+    parameter_values : list of `nterms` scalars or ndarrays
         Parameter values at which the operators vectors are known.
     matrices : list of `nterms` ndarray, all of the same shape.
-        Operator vectors corresponding to the `parameter_samples`.
+        Operator vectors corresponding to the `parameter_values`.
     """
     _OperatorClass = ConstantOperator
     _InterpolatorClass = scipy.interpolate.CubicSpline
@@ -162,10 +165,10 @@ class Spline1dLinearOperator(_InterpolatedOperator):
 
     Attributes
     ----------
-    parameter_samples : list of `nterms` scalars or ndarrays
+    parameter_values : list of `nterms` scalars or ndarrays
         Parameter values at which the operators matrices are known.
     matrices : list of `nterms` ndarray, all of the same shape.
-        Operator matrices corresponding to the `parameter_samples`.
+        Operator matrices corresponding to the `parameter_values`.
     """
     _OperatorClass = LinearOperator
     _InterpolatorClass = scipy.interpolate.CubicSpline
@@ -181,10 +184,10 @@ class Spline1dQuadraticOperator(_InterpolatedOperator):
 
     Attributes
     ----------
-    parameter_samples : list of `nterms` scalars or ndarrays
+    parameter_values : list of `nterms` scalars or ndarrays
         Parameter values at which the operators matrices are known.
     matrices : list of `nterms` ndarray, all of the same shape.
-        Operator matrices corresponding to the `parameter_samples`.
+        Operator matrices corresponding to the `parameter_values`.
     """
     _OperatorClass = QuadraticOperator
     _InterpolatorClass = scipy.interpolate.CubicSpline
@@ -200,10 +203,10 @@ class Spline1dCubicOperator(_InterpolatedOperator):
 
     Attributes
     ----------
-    parameter_samples : list of `nterms` scalars or ndarrays
+    parameter_values : list of `nterms` scalars or ndarrays
         Parameter values at which the operators matrices are known.
     matrices : list of `nterms` ndarray, all of the same shape.
-        Operator matrices corresponding to the `parameter_samples`.
+        Operator matrices corresponding to the `parameter_values`.
     """
     _OperatorClass = CubicOperator
     _InterpolatorClass = scipy.interpolate.CubicSpline

--- a/src/rom_operator_inference/core/operators/_interpolate.py
+++ b/src/rom_operator_inference/core/operators/_interpolate.py
@@ -1,0 +1,205 @@
+# _interpolate.py
+"""Classes for operao
+"""
+
+__all__ = [
+    "Spline1dConstantOperator",
+    "Spline1dLinearOperator",
+    "Spline1dQuadraticOperator",
+    # Spline1dCrossQuadraticOperator",
+    "Spline1dCubicOperator",
+]
+
+import numpy as np
+import scipy.interpolate
+
+from ._nonparametric import (_BaseParametricOperator,
+                             ConstantOperator,
+                             LinearOperator,
+                             QuadraticOperator,
+                             CubicOperator)
+
+
+# Base class ==================================================================
+class _InterpolatedOperator(_BaseParametricOperator):
+    """Base class for parametric operators where the parameter dependence
+    is handled with element-wise interpolation, i.e.,
+
+    A(µ)[i,j] = Interpolator([µ1, µ2, ...], [A1[i,j], A2[i,j], ...])(µ).
+
+    Here A1 is the operator matrix corresponding to the parameter µ1, etc.
+    The matrix A(µ) for a given µ is constructed by calling the object.
+
+    Attributes
+    ----------
+    parameter_samples : list of `nterms` scalars or ndarrays
+        Parameter values at which the operators matrices are known.
+    matrices : list of `nterms` ndarray, all of the same shape.
+        Component matrices corresponding to the `parameter_samples`.
+    OperatorClass : class
+        Class of operator to construct, a subclass of
+        core.operators._BaseNonparametricOperator.
+    InterpolatorClass : scipy.interpolate class
+        Type of interpolator to use. Must obey the following syntax.
+        >>> interpolator_object = Interpolator(data_points, data_values)
+        >>> interpolator_evaluation = interpolator_object(new_data_point)
+    """
+    # Must be specified by child classes.
+    _InterpolatorClass = NotImplemented
+
+    @property
+    def InterpolatorClass(self):
+        """scipy.interpolate class for the elementwise interpolation."""
+        return self._InterpolatorClass
+
+    def __init__(self, parameter_samples, matrices, **kwargs):
+        """Construct the interpolator.
+
+        Parameters
+        ----------
+        parameter_samples : list of `nterms` scalars or ndarrays
+            Parameter values at which the operators matrices are known.
+        matrices : list of `nterms` ndarray, all of the same shape.
+            Operator entries corresponding to the `parameter_samples`.
+        kwargs
+            Additional arguments for the interpolator.
+        """
+        _BaseParametricOperator.__init__(self)
+
+        # Ensure there are the same number of parameter samples and matrices.
+        n_params, n_matrices = len(parameter_samples), len(matrices)
+        if n_params != n_matrices:
+            raise ValueError(f"{n_params} = len(parameter_samples) "
+                             f"!= len(matrices) = {n_matrices}")
+
+        # Ensure parameter / matrix shapes are consistent.
+        self._check_shape_consistency(parameter_samples, "parameter sample")
+        self._check_shape_consistency(matrices, "component matrix")
+
+        # Construct the spline.
+        self.__parameter_samples = parameter_samples
+        self.__matrices = matrices
+        self.__interpolator = self.InterpolatorClass(parameter_samples,
+                                                     matrices, **kwargs)
+
+    @property
+    def parameter_samples(self):                            # pragma: no cover
+        """Parameter values at which the operators matrices are known."""
+        return self.__parameter_samples
+
+    @property
+    def matrices(self):
+        """Operator matrices corresponding to the parameter_samples."""
+        return self.__matrices
+
+    @property
+    def interpolator(self):
+        """Interpolator object for evaluating the operator at a parameter."""
+        return self.__interpolator
+
+    def __call__(self, parameter):
+        """Return the nonparametric operator corresponding to the parameter."""
+        return self.OperatorClass(self.interpolator(parameter))
+
+    def __len__(self):
+        """Length: number of data points for the interpolation."""
+        return len(self.matrices)
+
+    def __eq__(self, other):
+        """Test whether the parameter samples and component matrices of two
+        InterpolatedOperator objects are numerically equal.
+        """
+        if not isinstance(other, self.__class__):
+            return False
+        if self.OperatorClass is not other.OperatorClass:
+            return False
+        if self.InterpolatorClass is not other.InterpolatorClass:
+            return False
+        if len(self) != len(other):
+            return False
+        if any(not np.all(left == right)
+               for left, right in zip(self.parameter_samples,
+                                      other.parameter_samples)):
+            return False
+        return all(np.all(left == right)
+                   for left, right in zip(self.matrices, other.matrices))
+
+
+# One-dimensional cubic spline operators ======================================
+class Spline1dConstantOperator(_InterpolatedOperator):
+    """Constant operator with 1D Spline interpolation, i.e.,
+
+        c(µ) = cubic_spline([µ1, µ2, ...], [c1[i,j], c2[i,j], ...])(µ),
+
+    where c1 is the operator vector corresponding to the parameter µ1, etc.
+    The vector c(µ) for a given µ is constructed by calling the object.
+
+    Attributes
+    ----------
+    parameter_samples : list of `nterms` scalars or ndarrays
+        Parameter values at which the operators vectors are known.
+    matrices : list of `nterms` ndarray, all of the same shape.
+        Operator vectors corresponding to the `parameter_samples`.
+    """
+    _OperatorClass = ConstantOperator
+    _InterpolatorClass = scipy.interpolate.CubicSpline
+
+
+class Spline1dLinearOperator(_InterpolatedOperator):
+    """Linear operator with elementwise 1D cubic spline interpolation, i.e.,
+
+        A(µ) = cubic_spline([µ1, µ2, ...], [A1[i,j], A2[i,j], ...])(µ),
+
+    where A1 is the operator matrix corresponding to the parameter µ1, etc.
+    The matrix A(µ) for a given µ is constructed by calling the object.
+
+    Attributes
+    ----------
+    parameter_samples : list of `nterms` scalars or ndarrays
+        Parameter values at which the operators matrices are known.
+    matrices : list of `nterms` ndarray, all of the same shape.
+        Operator matrices corresponding to the `parameter_samples`.
+    """
+    _OperatorClass = LinearOperator
+    _InterpolatorClass = scipy.interpolate.CubicSpline
+
+
+class Spline1dQuadraticOperator(_InterpolatedOperator):
+    """Quadratic operator with elementwise 1D cubic spline interpolation, i.e.,
+
+        H(µ) = cubic_spline([µ1, µ2, ...], [H1[i,j], H2[i,j], ...])(µ),
+
+    where H1 is the operator matrix corresponding to the parameter µ1, etc.
+    The matrix H(µ) for a given µ is constructed by calling the object.
+
+    Attributes
+    ----------
+    parameter_samples : list of `nterms` scalars or ndarrays
+        Parameter values at which the operators matrices are known.
+    matrices : list of `nterms` ndarray, all of the same shape.
+        Operator matrices corresponding to the `parameter_samples`.
+    """
+    _OperatorClass = QuadraticOperator
+    _InterpolatorClass = scipy.interpolate.CubicSpline
+
+
+class Spline1dCubicOperator(_InterpolatedOperator):
+    """Cubic operator with elementwise 1D cubic spline interpolation, i.e.,
+
+        G(µ) = cubic_spline([µ1, µ2, ...], [G1[i,j], G2[i,j], ...])(µ),
+
+    where G1 is the operator matrix corresponding to the parameter µ1, etc.
+    The matrix G(µ) for a given µ is constructed by calling the object.
+
+    Attributes
+    ----------
+    parameter_samples : list of `nterms` scalars or ndarrays
+        Parameter values at which the operators matrices are known.
+    matrices : list of `nterms` ndarray, all of the same shape.
+        Operator matrices corresponding to the `parameter_samples`.
+    """
+    _OperatorClass = CubicOperator
+    _InterpolatorClass = scipy.interpolate.CubicSpline
+
+
+# N-dimensional linear interpolation operators ================================

--- a/src/rom_operator_inference/core/operators/_interpolate.py
+++ b/src/rom_operator_inference/core/operators/_interpolate.py
@@ -1,5 +1,8 @@
 # _interpolate.py
-"""Classes for operao
+"""Classes for parametric operators where the parametric dependence is handled
+with element-wise interpolation, i.e.,
+
+    A(µ)[i,j] = Interpolator([µ1, µ2, ...], [A1[i,j], A2[i,j], ...])(µ).
 """
 
 __all__ = [
@@ -17,6 +20,7 @@ from ._nonparametric import (_BaseParametricOperator,
                              ConstantOperator,
                              LinearOperator,
                              QuadraticOperator,
+                             # CrossQuadraticOperator,
                              CubicOperator)
 
 
@@ -74,7 +78,7 @@ class _InterpolatedOperator(_BaseParametricOperator):
 
         # Ensure parameter / matrix shapes are consistent.
         self._check_shape_consistency(parameter_samples, "parameter sample")
-        self._check_shape_consistency(matrices, "component matrix")
+        self._check_shape_consistency(matrices, "operator matrix")
 
         # Construct the spline.
         self.__parameter_samples = parameter_samples
@@ -93,6 +97,11 @@ class _InterpolatedOperator(_BaseParametricOperator):
         return self.__matrices
 
     @property
+    def shape(self):
+        """Shape: shape of the operator matrices to interpolate."""
+        return self.matrices[0].shape
+
+    @property
     def interpolator(self):
         """Interpolator object for evaluating the operator at a parameter."""
         return self.__interpolator
@@ -106,7 +115,7 @@ class _InterpolatedOperator(_BaseParametricOperator):
         return len(self.matrices)
 
     def __eq__(self, other):
-        """Test whether the parameter samples and component matrices of two
+        """Test whether the parameter samples and operator matrices of two
         InterpolatedOperator objects are numerically equal.
         """
         if not isinstance(other, self.__class__):

--- a/tests/core/operators/test_affine.py
+++ b/tests/core/operators/test_affine.py
@@ -28,7 +28,7 @@ class TestAffineOperator:
         _OperatorClass = _OperatorDummy
 
     @staticmethod
-    def _set_up_affine_attributes(n=5):
+    def _set_up_affine_expansion(n=5):
         """Set up a valid affine expansion."""
         coefficient_functions = [np.sin, np.cos, np.exp]
         matrices = list(np.random.random((len(coefficient_functions), n, n)))
@@ -36,7 +36,7 @@ class TestAffineOperator:
 
     def test_init(self):
         """Test core.operators._affine._AffineOperator.__init__()."""
-        funcs, matrices = self._set_up_affine_attributes()
+        funcs, matrices = self._set_up_affine_expansion()
 
         # Try with non-callables.
         with pytest.raises(TypeError) as ex:
@@ -61,7 +61,7 @@ class TestAffineOperator:
 
     def test_properties(self):
         """Test _AffineOperator.[coefficient_functions|matrices|shape]."""
-        funcs, matrices = self._set_up_affine_attributes()
+        funcs, matrices = self._set_up_affine_expansion()
         op = self.Dummy(funcs, matrices)
 
         # Check coefficient_functions / matrices attributes.
@@ -80,7 +80,7 @@ class TestAffineOperator:
 
     def test_validate_coefficient_functions(self):
         """Test _AffineOperator._validate_coefficient_functions()."""
-        funcs, matrices = self._set_up_affine_attributes()
+        funcs, matrices = self._set_up_affine_expansion()
 
         # Try with non-callables.
         with pytest.raises(TypeError) as ex:
@@ -102,7 +102,7 @@ class TestAffineOperator:
 
     def test_call(self):
         """Test _AffineOperator.__call__()."""
-        funcs, matrices = self._set_up_affine_attributes()
+        funcs, matrices = self._set_up_affine_expansion()
 
         op = self.Dummy(funcs, matrices)
         A = op(10)
@@ -114,7 +114,7 @@ class TestAffineOperator:
 
     def test_eq(self):
         """Test _AffineOperator.__eq__()."""
-        funcs, matrices = self._set_up_affine_attributes()
+        funcs, matrices = self._set_up_affine_expansion()
         op1 = self.Dummy(funcs, matrices)
         op2 = self.Dummy(funcs[:-1], matrices[:-1])
 

--- a/tests/core/operators/test_affine.py
+++ b/tests/core/operators/test_affine.py
@@ -6,6 +6,8 @@ import numpy as np
 
 import rom_operator_inference as opinf
 
+from .. import _get_operators
+
 
 _module = opinf.core.operators._affine
 _base = opinf.core.operators._base
@@ -126,3 +128,46 @@ class TestAffineOperator:
 
         op2 = self.Dummy(funcs, matrices)
         assert op1 == op2
+
+
+def test_affineoperators(r=10, m=3, s=5):
+    """Test all affine operator classes by instantiating and calling."""
+    # Get nominal operators to play with.
+    c, A, H, G, B = _get_operators(r, m)
+
+    # Get interpolation data for each type of operator.
+    funcs = [np.sin, np.cos, np.exp]
+    cs = list(np.random.standard_normal((3,) + c.shape))
+    As = list(np.random.standard_normal((3,) + A.shape))
+    Hs = list(np.random.standard_normal((3,) + H.shape))
+    Gs = list(np.random.standard_normal((3,) + G.shape))
+    Bs = list(np.random.standard_normal((3,) + B.shape))
+
+    # Instantiate each affine operator.
+    caffineop = _module.AffineConstantOperator(funcs, cs)
+    Aaffineop = _module.AffineLinearOperator(funcs, As)
+    Haffineop = _module.AffineQuadraticOperator(funcs, Hs)
+    Gaffineop = _module.AffineCubicOperator(funcs, Gs)
+    Baffineop = _module.AffineLinearOperator(funcs, Bs)
+
+    # Call each affine operator on a new parameter.
+    p = .314159
+    c_new = caffineop(p)
+    assert isinstance(c_new, opinf.core.operators.ConstantOperator)
+    assert c_new.shape == c.shape
+
+    A_new = Aaffineop(p)
+    assert isinstance(A_new, opinf.core.operators.LinearOperator)
+    assert A_new.shape == A.shape
+
+    H_new = Haffineop(p)
+    assert isinstance(H_new, opinf.core.operators.QuadraticOperator)
+    assert H_new.shape == H.shape
+
+    G_new = Gaffineop(p)
+    assert isinstance(G_new, opinf.core.operators.CubicOperator)
+    assert G_new.shape == G.shape
+
+    B_new = Baffineop(p)
+    assert isinstance(B_new, opinf.core.operators.LinearOperator)
+    assert B_new.shape == B.shape

--- a/tests/core/operators/test_affine.py
+++ b/tests/core/operators/test_affine.py
@@ -1,0 +1,128 @@
+# core/operators/test_affine.py
+"""Tests for rom_operator_inference.core.operators._affine."""
+
+import pytest
+import numpy as np
+
+import rom_operator_inference as opinf
+
+
+_module = opinf.core.operators._affine
+_base = opinf.core.operators._base
+
+
+class _OperatorDummy(_base._BaseNonparametricOperator):
+    """Instantiable version of _BaseNonparametricOperator."""
+    def __init__(self, entries):
+        _base._BaseNonparametricOperator.__init__(self, entries)
+
+    def __call__(*args, **kwargs):
+        return 0
+
+
+class TestAffineOperator:
+    """Test opinf.core.operators._affine._AffineOperator."""
+
+    class Dummy(_module._AffineOperator):
+        """Instantiable version of core.operators._affine._AffineOperator."""
+        _OperatorClass = _OperatorDummy
+
+    @staticmethod
+    def _set_up_affine_attributes(n=5):
+        """Set up a valid affine expansion."""
+        coefficient_functions = [np.sin, np.cos, np.exp]
+        matrices = list(np.random.random((len(coefficient_functions), n, n)))
+        return coefficient_functions, matrices
+
+    def test_init(self):
+        """Test core.operators._affine._AffineOperator.__init__()."""
+        funcs, matrices = self._set_up_affine_attributes()
+
+        # Try with non-callables.
+        with pytest.raises(TypeError) as ex:
+            self.Dummy(matrices, matrices)
+        assert ex.value.args[0] == \
+            "coefficient functions of affine operator must be callable"
+
+        # Try with different number of functions and matrices.
+        with pytest.raises(ValueError) as ex:
+            self.Dummy(funcs, matrices[:-1])
+        assert ex.value.args[0] == \
+            f"{len(funcs)} = len(coefficient_functions) " \
+            f"!= len(matrices) = {len(matrices[:-1])}"
+
+        # Try with matrices of different shapes.
+        with pytest.raises(ValueError) as ex:
+            self.Dummy(funcs, matrices[:-1] + [np.random.random((10,2))])
+        assert ex.value.args[0] == "operator matrix shapes inconsistent"
+
+        # Correct usage.
+        self.Dummy(funcs, matrices)
+
+    def test_properties(self):
+        """Test _AffineOperator.[coefficient_functions|matrices|shape]."""
+        funcs, matrices = self._set_up_affine_attributes()
+        op = self.Dummy(funcs, matrices)
+
+        # Check coefficient_functions / matrices attributes.
+        assert op.coefficient_functions is funcs
+        assert op.matrices is matrices
+
+        # Check shape attribute.
+        for A in matrices:
+            assert op.shape == A.shape
+
+        # Ensure these attributes are all properties.
+        for attr in ["coefficient_functions", "matrices", "shape"]:
+            with pytest.raises(AttributeError) as ex:
+                setattr(op, attr, 10)
+            assert ex.value.args[0] == "can't set attribute"
+
+    def test_validate_coefficient_functions(self):
+        """Test _AffineOperator._validate_coefficient_functions()."""
+        funcs, matrices = self._set_up_affine_attributes()
+
+        # Try with non-callables.
+        with pytest.raises(TypeError) as ex:
+            self.Dummy._validate_coefficient_functions(matrices, matrices)
+        assert ex.value.args[0] == \
+            "coefficient functions of affine operator must be callable"
+
+        # Try with vector-valued functions.
+        def f1(t):
+            return np.array([t, t**2])
+
+        with pytest.raises(ValueError) as ex:
+            self.Dummy._validate_coefficient_functions([f1, f1], 10)
+        assert ex.value.args[0] == \
+            "coefficient functions of affine operator must return a scalar"
+
+        # Correct usage.
+        self.Dummy._validate_coefficient_functions(funcs, 10)
+
+    def test_call(self):
+        """Test _AffineOperator.__call__()."""
+        funcs, matrices = self._set_up_affine_attributes()
+
+        op = self.Dummy(funcs, matrices)
+        A = op(10)
+        assert isinstance(A, _OperatorDummy)
+        assert A.shape == op.shape
+
+        A_true = sum([funcs[i](10)*matrices[i] for i in range(len(op))])
+        assert np.allclose(A.entries, A_true)
+
+    def test_eq(self):
+        """Test _AffineOperator.__eq__()."""
+        funcs, matrices = self._set_up_affine_attributes()
+        op1 = self.Dummy(funcs, matrices)
+        op2 = self.Dummy(funcs[:-1], matrices[:-1])
+
+        assert op1 != 1
+        assert op1 != op2
+
+        op2 = self.Dummy(funcs, [A[:,:-1] for A in matrices])
+        assert op1 != op2
+
+        op2 = self.Dummy(funcs, matrices)
+        assert op1 == op2

--- a/tests/core/operators/test_base.py
+++ b/tests/core/operators/test_base.py
@@ -66,8 +66,62 @@ class TestBaseNonparametricOperator:
         opA2 = self.Dummy2(A)
         assert opA != opA2
 
+        opAT = self.Dummy(A.T)
+        assert opA != opAT
+
         opB = self.Dummy(A + 1)
         assert opA != opB
 
         opC = self.Dummy(A + 0)
         assert opA == opC
+
+
+class TestBaseParametricOperator:
+    """Test core.operators._nonparametric._BaseNonparametricOperator."""
+    class Dummy(_module._BaseParametricOperator):
+        """Instantiable version of _BaseParametricOperator."""
+        _OperatorClass = _module._BaseNonparametricOperator
+
+        def __init__(self):
+            super().__init__()
+
+        def __call__(*args, **kwargs):
+            pass
+
+    class BadDummy(_module._BaseParametricOperator):
+        """Instantiable but incorrect version of _BaseNonparametricOperator."""
+        _OperatorClass = int
+
+        def __init__(self):
+            super().__init__()
+
+        def __call__(*args, **kwargs):
+            pass
+
+    def test_init(self):
+        """Test _BaseParametricOperator.__init__() and .OperatorClass."""
+        # Make sure Dummy is instantiable and has the right OperatorClass.
+        dummy = self.Dummy()
+        assert dummy.OperatorClass is _module._BaseNonparametricOperator
+
+        # Try changing the OperatorClass.
+        with pytest.raises(AttributeError) as ex:
+            dummy.OperatorClass = int
+        assert ex.value.args[0] == "can't set attribute"
+
+        # Try instantiating a class with an invalid OperatorClass.
+        with pytest.raises(RuntimeError) as ex:
+            self.BadDummy()
+        assert ex.value.args[0] == "invalid OperatorClass 'int'"
+
+    def test_check_shape_consistency(self):
+        """Test _BaseNonparametricOperator._check_shape_consistency()."""
+        X = np.arange(12).reshape((3, 4))
+
+        matrices = [X, X, X.T, X]
+        with pytest.raises(ValueError) as ex:
+            self.Dummy._check_shape_consistency(matrices, "input")
+        assert ex.value.args[0] == "input shapes inconsistent"
+
+        matrices = [X, X+1, X/2, X*0]
+        self.Dummy._check_shape_consistency(matrices, "arguments")

--- a/tests/core/operators/test_interpolate.py
+++ b/tests/core/operators/test_interpolate.py
@@ -1,0 +1,174 @@
+# core/operators/test_interpolate.py
+"""Tests for rom_operator_inference.core.operators._interpolate."""
+
+import pytest
+import numpy as np
+
+import rom_operator_inference as opinf
+
+from .. import _get_operators
+
+_module = opinf.core.operators._interpolate
+_base = opinf.core.operators._base
+
+
+class _OperatorDummy(_base._BaseNonparametricOperator):
+    """Instantiable version of _BaseNonparametricOperator."""
+    def __init__(self, entries):
+        _base._BaseNonparametricOperator.__init__(self, entries)
+
+    def __call__(*args, **kwargs):
+        return 0
+
+
+class _InterpolatorDummy:
+    """Dummy class for interpolator that obeys the following syntax.
+    >>> interpolator_object = _InterpolatorDummy(data_points, data_values)
+    >>> interpolator_evaluation = interpolator_object(new_data_point)
+    Since this is a dummy, no actual interpolation or evaluation takes place.
+    """
+    def __init__(self, points, values, **kwargs):
+        self.__values = values[0]
+
+    def __call__(self, newpoint):
+        return self.__values
+
+
+class TestIterpolatedOperator:
+    """Test opinf.core.operators._interpolate._InterpolatedOperator."""
+
+    class Dummy(_module._InterpolatedOperator):
+        """Instantiable version of _InterpolatedOperator."""
+        _OperatorClass = _OperatorDummy
+        _InterpolatorClass = _InterpolatorDummy
+
+    @staticmethod
+    def _set_up_interpolation_data(numpoints=4, shape=(10, 10)):
+        """Set up points / values for dummy interpolation data."""
+        parameters = np.linspace(0, 1, numpoints)
+        matrices = list(np.random.random(((numpoints,) + shape)))
+        return parameters, matrices
+
+    def test_init(self):
+        """Test _InterpolatedOperator.__init__()."""
+        params, matrices = self._set_up_interpolation_data()
+
+        # Try with different number of interpolation points and matrices.
+        with pytest.raises(ValueError) as ex:
+            self.Dummy(params, matrices[:-1])
+        assert ex.value.args[0] == \
+            f"{len(params)} = len(parameter_values) " \
+            f"!= len(matrices) = {len(matrices[:-1])}"
+
+        # Try with parameters of different shapes.
+        params_bad = list(np.random.random((len(matrices), 2)))
+        params_bad[0] = np.random.random(3)
+        with pytest.raises(ValueError) as ex:
+            self.Dummy(params_bad, matrices)
+        assert ex.value.args[0] == "parameter sample shapes inconsistent"
+
+        # Try with matrices of different shapes.
+        with pytest.raises(ValueError) as ex:
+            self.Dummy(params, matrices[:-1] + [np.random.random((10,2))])
+        assert ex.value.args[0] == "operator matrix shapes inconsistent"
+
+        # Correct usage.
+        self.Dummy(params, matrices)
+
+    def test_properties(self):
+        """Test _InterpolatedOperator properties,
+        parameter_values, matrices, shape, and interpolator.
+        """
+        params, matrices = self._set_up_interpolation_data()
+        op = self.Dummy(params, matrices)
+
+        # Check parameter_values / matrices attributes.
+        assert op.parameter_values is params
+        assert op.matrices is matrices
+        assert isinstance(op.interpolator, _InterpolatorDummy)
+
+        # Check shape attribute.
+        for A in matrices:
+            assert op.shape == A.shape
+
+        # Ensure these attributes are all properties.
+        for attr in ["parameter_values", "matrices", "shape", "interpolator"]:
+            with pytest.raises(AttributeError) as ex:
+                setattr(op, attr, 10)
+            assert ex.value.args[0] == "can't set attribute"
+
+    def test_call(self):
+        """Test _InterpolatedOperator.__call__()."""
+        params, matrices = self._set_up_interpolation_data()
+
+        op = self.Dummy(params, matrices)
+        A = op(.314159)
+        assert isinstance(A, _OperatorDummy)
+        assert A.shape == op.shape
+
+    def test_eq(self):
+        """Test _InterpolatedOperator.__eq__()."""
+        params, matrices = self._set_up_interpolation_data()
+        op1 = self.Dummy(params, matrices)
+        op2 = self.Dummy(params[:-1], matrices[:-1])
+
+        assert op1 != 1
+        assert op1 != op2
+
+        op2 = self.Dummy(params, [A[:,:-1] for A in matrices])
+        assert op1 != op2
+
+        op2 = self.Dummy(np.random.random((len(params), 11)), matrices)
+        assert op1 != op2
+
+        op2 = self.Dummy(params - 1, matrices)
+        assert op1 != op2
+
+        op2 = self.Dummy(params, matrices)
+        assert op1 == op2
+
+
+def test_spline1Doperators(r=10, m=3, s=5):
+    """Test all Spline1d operator classes by instantiating and calling."""
+    # Get nominal operators to play with.
+    c, A, H, G, B = _get_operators(r, m)
+
+    # Get interpolation data for each type of operator.
+    params = np.linspace(0, 1, s)
+    cs = [c + p**2 + np.random.standard_normal(c.shape)/20 for p in params]
+    As = [A + p**2 + np.random.standard_normal(A.shape)/20 for p in params]
+    Hs = [H + p**2 + np.random.standard_normal(H.shape)/20 for p in params]
+    Gs = [G + p**2 + np.random.standard_normal(G.shape)/20 for p in params]
+    Bs = [B + p**2 + np.random.standard_normal(B.shape)/20 for p in params]
+
+    # Instantiate each Spline1d operator.
+    csplineop = _module.Spline1dConstantOperator(params, cs)
+    Asplineop = _module.Spline1dLinearOperator(params, As)
+    Hsplineop = _module.Spline1dQuadraticOperator(params, Hs)
+    Gsplineop = _module.Spline1dCubicOperator(params, Gs)
+    Bsplineop = _module.Spline1dLinearOperator(params, Bs)
+
+    # Call each Spline1d operator on a new parameter.
+    p = .314159
+    c_new = csplineop(p)
+    assert isinstance(c_new, opinf.core.operators.ConstantOperator)
+    assert c_new.shape == c.shape
+
+    A_new = Asplineop(p)
+    assert isinstance(A_new, opinf.core.operators.LinearOperator)
+    assert A_new.shape == A.shape
+
+    H_new = Hsplineop(p)
+    assert isinstance(H_new, opinf.core.operators.QuadraticOperator)
+    assert H_new.shape == H.shape
+
+    G_new = Gsplineop(p)
+    assert isinstance(G_new, opinf.core.operators.CubicOperator)
+    assert G_new.shape == G.shape
+
+    B_new = Bsplineop(p)
+    assert isinstance(B_new, opinf.core.operators.LinearOperator)
+    assert B_new.shape == B.shape
+
+
+# TODO: interpolation options other than 1D cubic splines.


### PR DESCRIPTION
- Implemented Affine operators in `core/operators/_affine.py` and unit tests in `tests/operators/test_affine.py`
- Implemented interpolated operators in `core/operators/_interpolate.py` and unit tests in `tests/operators/test_interpolate.py`.

These classes inherit from `core.operators._base._BaseParametricOperator`, which now has an `OperatorClass` property that determines the return type of `__call__()`. This must be a subclass of `core.operators._base._BaseNonparametricOperator`. Updated the developer documentation to reflect this change.

Currently only have interpolation operators that use `scipy.interpolate.CubicSpline` as the backend, but it will be very easy to add more `scipy.interpolate`-based operators.

Affine and interpolated ROM classes are still TODO.