### PR TITLE
Jacobians

### DIFF
--- a/docs/content/tutorials/basics.ipynb
+++ b/docs/content/tutorials/basics.ipynb
@@ -389,7 +389,7 @@
     "$$\n",
     "\n",
     "with $\\mathbf{q}(t)\\in\\mathbb{R}^{n}$ and $\\mathbf{A}\\in\\mathbb{R}^{n\\times n}$.\n",
-    "Because projection preserves the linear structure of the equations, we seek a ROM with a linear structure,\n",
+    "Because Galerkin projection preserves the linear structure of the equations, we seek a ROM with a linear structure,\n",
     "\n",
     "$$\n",
     "    \\frac{\\text{d}}{\\text{d}t}\\widehat{\\mathbf{q}}(t)\n",
@@ -716,8 +716,8 @@
    "metadata": {},
    "source": [
     ":::{tip}\n",
-    "The finite difference approximation for $\\dot{\\mathbf{Q}}$ commutes with the projection to a low-dimensional subspace, that is, $\\mathbf{V}_{r}^\\top\\frac{\\text{d}}{\\text{d}t}\\left[\\mathbf{Q}\\right] = \\frac{\\text{d}}{\\text{d}t}\\left[\\mathbf{V}_{r}^{\\top}\\mathbf{Q}\\right]$.\n",
-    "To save memory, the snapshot matrix may be projected first, and the projected time derivatives can be calculated from the projected snapshots.\n",
+    "The finite difference approximation for $\\dot{\\mathbf{Q}}$ commutes with the encoding in a low-dimensional subspace, that is, $\\mathbf{V}_{r}^\\top\\frac{\\text{d}}{\\text{d}t}\\left[\\mathbf{Q}\\right] = \\frac{\\text{d}}{\\text{d}t}\\left[\\mathbf{V}_{r}^{\\top}\\mathbf{Q}\\right]$.\n",
+    "To save memory, the snapshot matrix may be encoded first, and the time derivatives can be calculated from the encoded snapshots.\n",
     "The ROM classes in the next section accept both full-order ($n \\times k$) or reduced-order ($r\\times k$) snapshot and time derivative matrices as training data.\n",
     ":::"
    ]
@@ -728,10 +728,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Q_ = Vr.T @ Q                                   # Project the state snapshots.\n",
-    "Qdot_ = opinf.pre.ddt_uniform(Q_, dt, order=6)  # Estimate the projected time derivatives.\n",
+    "Q_ = Vr.T @ Q                                   # Encode the state snapshots.\n",
+    "Qdot_ = opinf.pre.ddt_uniform(Q_, dt, order=6)  # Estimate time derivatives of encoded states.\n",
     "\n",
-    "np.allclose(Vr.T @ Qdot2, Qdot_)                # Same as project the full-order time derivatives."
+    "np.allclose(Vr.T @ Qdot2, Qdot_)                # Same as encoding the full-order time derivatives."
    ]
   },
   {
@@ -886,7 +886,7 @@
     "(subsec-tutorial-regularization)=\n",
     "#### Regularization: Stabilizing the Inference Problem\n",
     "\n",
-    "Solving {eq}`eq_basics_opinf` numerically can be challenging due to ill-conditioning in the projected data or overfitting.\n",
+    "Solving {eq}`eq_basics_opinf` numerically can be challenging due to ill-conditioning in the data or overfitting.\n",
     "The inference problem therefore often requires a _regularization_ strategy to obtain a solution that respects both the training data and the physics of the problem.\n",
     "One common option, implemented by this package, is [Tikhonov regularization](https://en.wikipedia.org/wiki/Tikhonov_regularization), which sets $\\mathcal{R}(\\widehat{\\mathbf{A}}) = \\|\\lambda\\widehat{\\mathbf{A}}\\|_{F}^{2}$ in {eq}`eq_basics_opinf` to penalize the entries of the learned operators.\n",
     "The scalar $\\lambda$ can be included as the argument `regularizer` in the `fit()` method."
@@ -916,7 +916,7 @@
    "metadata": {},
    "source": [
     ":::{note}\n",
-    "With $\\lambda = 10^{-2}$, OpInf no longer quite recovers the intrusive operator $\\widetilde{\\mathbf{A}}$. However, we will see in the next section that the ROM produced by OpInf is highly accurate. In fact, it is often the case that OpInf outperforms intrusive projection.\n",
+    "With $\\lambda = 10^{-2}$, OpInf no longer quite recovers the intrusive operator $\\widetilde{\\mathbf{A}}$. However, we will see in the next section that the ROM produced by OpInf is highly accurate. In fact, it is sometimes the case that OpInf outperforms intrusive projection.\n",
     ":::"
    ]
   },
@@ -943,7 +943,7 @@
    "metadata": {},
    "source": [
     "Once the model is fit, we may simulate the ROM with the `predict()` method, which wraps `scipy.integrate.solve_ivp()`.\n",
-    "This method takes an initial condition from the original space $\\mathbb{R}^n$, projects it to $\\mathbb{R}^r$, simulates the ROM in $\\mathbb{R}^r$, and maps the results to $\\mathbb{R}^n$."
+    "This method takes an initial condition from the original space $\\mathbb{R}^n$, encodes it in $\\mathbb{R}^r$, simulates the ROM in $\\mathbb{R}^r$, and decodes the results to $\\mathbb{R}^n$."
    ]
   },
   {

--- a/docs/content/tutorials/heat_equation.ipynb
+++ b/docs/content/tutorials/heat_equation.ipynb
@@ -536,8 +536,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Like the FOM, we integrate the learned ROM using the implicit Euler method, using the reduced-order operators $\\widehat{\\mathbf{A}}$ and $\\widehat{\\mathbf{B}}$ and the projected initial condition $\\widehat{\\mathbf{q}}_{0} = \\mathbf{V}^{\\mathsf{T}}\\mathbf{q}_{0}$.\n",
-    "The resulting low-dimensional state vectors are translated back to the full-dimensional space via $\\mathbf{q}(t) = \\mathbf{V}_{r}\\widehat{\\mathbf{q}}(t)$."
+    "Like the FOM, we integrate the learned ROM using the implicit Euler method, using the reduced-order operators $\\widehat{\\mathbf{A}}$ and $\\widehat{\\mathbf{B}}$ and the initial condition $\\widehat{\\mathbf{q}}_{0} = \\mathbf{V}^{\\mathsf{T}}\\mathbf{q}_{0}$.\n",
+    "The resulting low-dimensional state vectors are decoded back to the full-dimensional space via $\\mathbf{q}(t) = \\mathbf{V}_{r}\\widehat{\\mathbf{q}}(t)$."
    ]
   },
   {
@@ -1400,7 +1400,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are several strategies to account for the parameter $\\mu$. The reduced-order operators obtained through projection are given by\n",
+    "There are several strategies to account for the parameter $\\mu$. The reduced-order operators obtained through intrusive projection are given by\n",
     "\n",
     "$$\n",
     "    \\widetilde{\\mathbf{A}}(\\mu)\n",

--- a/docs/content/usage/postprocessing/index.md
+++ b/docs/content/usage/postprocessing/index.md
@@ -1,7 +1,7 @@
 # Postprocessing
 
 :::{admonition} Coming Soon!
-:class: important
+:class: attention
 This page is under construction.
 :::
 

--- a/docs/content/usage/preprocessing/scaling.ipynb
+++ b/docs/content/usage/preprocessing/scaling.ipynb
@@ -1,0 +1,353 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d4b92eb1-bb31-448b-b408-94b13219d6dd",
+   "metadata": {},
+   "source": [
+    "(sec-pre-scaling)=\n",
+    "# Data Scaling"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89397136-e29d-43c6-9f10-f3ea35db962a",
+   "metadata": {},
+   "source": [
+    ":::{admonition} Coming Soon!\n",
+    ":class: attention\n",
+    "This page is under construction.\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96e867db-4e8f-4098-9cc9-427ac0a93f52",
+   "metadata": {},
+   "source": [
+    "Raw dynamical systems data often need to be lightly preprocessed before use in Operator Inference.\n",
+    "This page discusses the tools provided in the package for\n",
+    "- centering or shifting to account for boundary conditions, and\n",
+    "- scaling / nondimensionalizing the variables represented in the state.\n",
+    "\n",
+    "In this guide, we use $\\mathbf{s}(t)$ to denote the unprocessed state variable for which we have data $\\mathbf{s}_{j} = \\mathbf{s}(t_{j})$, $j=0, \\ldots, k-1$. We use $\\mathbf{q}(t)$ to denote the processed state variable which we will use for Operator Inference.\n",
+    "Choosing an advantageous preprocessing $\\mathbf{s}(t) \\mapsto \\mathbf{q}(t)$ is highly problem dependent, and the tools shown here are not the only ways to preprocess snapshot data. See, for example, {cite}`issan2022shiftedopinf` for a compelling application of Operator Inference to solar wind streams in which preprocessing plays a vital role."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a21aae19-47b0-49b3-9b8b-ee3f51ea92ec",
+   "metadata": {},
+   "source": [
+    "::::{note}\n",
+    "The following code uses data pulled from the combustion problem described in {cite}`swischuk2020combustion`. The data consists of nine variables recorded at 100 points in time.\n",
+    "\n",
+    ":::{dropdown} Snapshot Variables\n",
+    "\n",
+    "- Pressure $p$\n",
+    "- $x$-velocity $v_{x}$\n",
+    "- $y$-velocity $v_{y}$\n",
+    "- Temperature $T$\n",
+    "- Specific volume $\\xi$\n",
+    "- Chemical species molar concentrations for CH$_{4}$, O$_{2}$, CO$_{2}$, and H$_{2}$O.\n",
+    "\n",
+    "The dimension of the spatial discretization in the full example in {cite}`swischuk2020combustion` is $38{,}523$ per variable, so that $\\mathbf{s}(t)$ has dimension $346{,}707$. Here we have downsampled the state dimension to $535$ for each variable for demonstration purposes.\n",
+    ":::\n",
+    "\n",
+    "You can [download the data here](https://github.com/Willcox-Research-Group/rom-operator-inference-Python3/raw/data/data_scaling_example.npy) to repeat the experiments.\n",
+    "::::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dfb814c0-1ab9-484a-9d0c-012910d67150",
+   "metadata": {},
+   "source": [
+    "## Shifting / Centering\n",
+    "\n",
+    "A common first preprocessing step is to shift the training snapshots by some reference snapshot $\\bar{\\mathbf{s}}$, i.e.,\n",
+    "\n",
+    "$$\n",
+    "    \\mathbf{q}(t) = \\mathbf{s}(t) - \\bar{\\mathbf{s}}.\n",
+    "$$\n",
+    "\n",
+    "For example, the reference snapshot could be chosen to be the average of the training snapshots:\n",
+    "\n",
+    "$$\n",
+    "    \\bar{\\mathbf{s}}\n",
+    "    := \\frac{1}{k}\\sum_{j=0}^{k-1}\\mathbf{s}_{j}.\n",
+    "$$\n",
+    "\n",
+    "In this case, the transformed snapshots $\\mathbf{q}_{j} = \\mathbf{s}_{j} - \\bar{\\mathbf{s}}$ are centered around $\\mathbf{0}$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d57b47c5-5fd2-4a39-9749-9237180774f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import scipy.linalg as la\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import opinf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b0296f1-0764-455d-b35e-1011b21fa07d",
+   "metadata": {
+    "tags": [
+     "hide-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Matplotlib customizations.\n",
+    "plt.rc(\"axes.spines\", right=False, top=False)\n",
+    "plt.rc(\"figure\", dpi=300, figsize=(9, 3))\n",
+    "plt.rc(\"font\", family=\"serif\")\n",
+    "plt.rc(\"legend\", edgecolor=\"none\", frameon=False)\n",
+    "plt.rc(\"text\", usetex=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "adaf1955-228a-4676-8df3-7b5fb184ba8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load snapshot data and extract just the pressure variable.\n",
+    "snapshots = np.load(\"data_scaling_example.npy\")\n",
+    "pressure = np.split(snapshots, 9, axis=0)[0]\n",
+    "\n",
+    "# Shift the pressure snapshots by the average pressure snapshot.\n",
+    "pressure_shifted, reference_snapshot = opinf.pre.shift(pressure)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab067c18-c88c-4a46-8883-297f1d314ab0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Average pressure value.\n",
+    "np.mean(pressure)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7256d13-cd4c-41d7-8803-b2d53e4ba2eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Average shifted pressure value.\n",
+    "np.mean(pressure_shifted)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9074bc35-ab0f-4663-9ad9-f6ae2fc41464",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot the distribution of the entries of the raw and processed states.\n",
+    "fig, axes = plt.subplots(1, 2, sharey=True)\n",
+    "axes[0].hist(pressure.flatten(), bins=40)\n",
+    "axes[1].hist(pressure_shifted.flatten(), bins=40)\n",
+    "axes[0].set_ylabel(\"Frequency\")\n",
+    "axes[0].set_xlabel(\"Pressure\")\n",
+    "axes[1].set_xlabel(\"Shifted pressure\")\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e67335a-d5c2-4f60-8ad9-baa147653fcd",
+   "metadata": {},
+   "source": [
+    "The reference snapshot may also represent boundary conditions or other physical constraints. See {cite}`swischuk2019physicsml` for examples."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c182a12e-d52a-4a1c-96cf-e1dcfda364f5",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Scaling\n",
+    "\n",
+    "Many engineering problems feature multiple variables with ranges across different scales. For such cases, it is often beneficial to scale the variables to similar ranges so that one variable does not overwhelm the other in the operator learning.\n",
+    "\n",
+    "A simple scaling is given by\n",
+    "\n",
+    "$$\n",
+    "    \\mathbf{q}(t) = \\frac{1}{\\alpha}\\mathbf{s}(t),\n",
+    "$$\n",
+    "\n",
+    "where $\\alpha$ is chosen by examining the range of the training data. For example, by first centering data a scaling to $[-1, 1]$ is given by\n",
+    "\n",
+    "$$\n",
+    "    \\mathbf{q}(t)\n",
+    "    = \\frac{1}{\\alpha}\\big(\\mathbf{s}(t) - \\bar{\\mathbf{s}}(t)\\big),\n",
+    "    \\qquad\n",
+    "    \\alpha = \\max_{i,j}|\\tilde{s}_{ij}|\n",
+    "$$\n",
+    "\n",
+    "where $\\tilde{s}_{ij}$ is the $i$th entry of $\\mathbf{s}_{j} - \\bar{\\mathbf{s}}$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35f41d1a-a7b5-431e-a603-1aeab50eecec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Extract the H2O molar concentration.\n",
+    "water = np.split(snapshots, 9, axis=0)[-1]\n",
+    "\n",
+    "# Compare the scales of the variables.\n",
+    "print(f\"Pressure range (raw):\\t\\t[{pressure.min():.2e}, {pressure.max():.2e}]\")\n",
+    "print(f\"Pressure range (shifted):\\t[{pressure_shifted.min():.2e}, {pressure_shifted.max():.2e}]\")\n",
+    "print(f\"Water range:\\t\\t\\t[{water.min():.2e}, {water.max():.2e}]\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a36a6ef5-eeb5-4fde-a0cb-28214f4a4fe3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Apply a min-max scaling to [0, .01] on the shifted pressure snapshots.\n",
+    "pressure_scaled, pscale1, pscale2 = opinf.pre.scale(pressure_shifted, (0, 1e-2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66df3c8c-e562-4085-b0b1-c8c0de9ad570",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compare the scales of the variables.\n",
+    "print(f\"Pressure range (raw):\\t\\t[{pressure.min():.2e}, {pressure.max():.2e}]\")\n",
+    "print(f\"Pressure range (shifted):\\t[{pressure_shifted.min():.2e}, {pressure_shifted.max():.2e}]\")\n",
+    "print(f\"Pressure range (scaled):\\t[{pressure_scaled.min():.2e}, {pressure_scaled.max():.2e}]\")\n",
+    "print(f\"Water range:\\t\\t\\t[{water.min():.2e}, {water.max():.2e}]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e6afb14-3a33-4aed-be8a-49a158de967b",
+   "metadata": {},
+   "source": [
+    "## The SnapshotTransformer Class\n",
+    "\n",
+    "The class `pre.SnapshotTransformer` bundles shifting and scaling transformations and their inverses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ae78829-8e25-4e5c-8972-d26d7381bd44",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "st = opinf.pre.SnapshotTransformer(center=True, scaling=\"standard\", verbose=True)\n",
+    "pressure_preprocessed = st.fit_transform(pressure)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d62c3078-2646-412e-ac2b-c1fec1534b98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "st = opinf.pre.SnapshotTransformer(scaling=\"maxabssym\", byrow=True, verbose=True).fit(pressure)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27296236-9f3c-42dc-a586-1dd5af5d5ae9",
+   "metadata": {},
+   "source": [
+    "The constructor accepts arguments to set the type of shifting / scaling transformation.\n",
+    "The `fit()` and `fit_transform()` methods learn the particular transformation, and `fit_transform()` or `transform()` applies the learned transformation.\n",
+    "The `inverse_transform()` method applies the inverse of the learned transformation.\n",
+    "\n",
+    "Constructor arguments:\n",
+    "- `center`: If `True`, shift the snapshots by the mean training snapshot.\n",
+    "- `scaling`: If given, scale (non-dimensionalize) the (centered) snapshot entries. Options:\n",
+    "    - `'standard'`: standardize to zero mean and unit standard deviation.\n",
+    "    - `'minmax'`: minmax scaling to [0, 1].\n",
+    "    - `'minmaxsym'`: minmax scaling to [-1, 1].\n",
+    "    - `'maxabs'`: maximum absolute scaling to [-1, 1] (no shift).\n",
+    "    - `'maxabssym'`: maximum absolute scaling to [-1, 1] (with mean shift).\n",
+    "- `byrow`: If `True`, scale each row of the snapshot matrix separately when a\n",
+    "    scaling is specified. Otherwise, scale the entire snapshot matrix at once.\n",
+    "- `verbose`: If `True`, print information upon learning a transformation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9d4570a-5fb7-4219-add7-e4cc0eb37941",
+   "metadata": {},
+   "source": [
+    "## The SnapshotTranformerMulti Class\n",
+    "\n",
+    "The class `pre.SnapshotTransformerMulti` handles multivariable data by constructing a separate `SnapshotTransformer` for each variable.\n",
+    "The constructor accepts the number of snapshot variables and the same parameters as the constructor of `pre.SnapshotTransformer`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e920574-4d63-4e6a-917f-09787b7b691a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Learn the variable transformation used in the paper.\n",
+    "stm = opinf.pre.SnapshotTransformerMulti(9,\n",
+    "    center=(True, False, False, True, False, False, False, False, False),\n",
+    "    scaling=(\"maxabs\", \"maxabs\", \"maxabs\", \"maxabs\", None, None, None, None, None),\n",
+    "    variable_names=[\"p\", \"vx\", \"vy\", \"T\", \"xi\", \"CH4\", \"O2\", \"CO2\", \"H2O\"],\n",
+    "    verbose=True)\n",
+    "\n",
+    "snapshots_preprocessed = stm.fit_transform(snapshots)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/content/usage/solvers/index.md
+++ b/docs/content/usage/solvers/index.md
@@ -2,7 +2,7 @@
 # Least-Squares Solvers
 
 :::{admonition} Coming Soon!
-:class: important
+:class: attention
 This page is under construction.
 :::
 

--- a/src/opinf/core/operators/_base.py
+++ b/src/opinf/core/operators/_base.py
@@ -75,10 +75,10 @@ class _BaseNonparametricOperator(abc.ABC):
         """Apply the operator mapping to the given states / inputs."""
         raise NotImplementedError
 
-    # @abc.abstractmethod                                   # pragma: no cover
-    # def jacobian(self, *args, **kwargs):
-    #     """Construct the Jacobian of the operator at the given state."""
-    #     raise NotImplementedError
+    @abc.abstractmethod                                     # pragma: no cover
+    def jacobian(self, *args, **kwargs):
+        """Construct the Jacobian of the operator at the given state."""
+        raise NotImplementedError
 
     def __call__(self, *args, **kwargs):
         """Apply the operator mapping to the given states / inputs."""

--- a/tests/core/operators/test_affine.py
+++ b/tests/core/operators/test_affine.py
@@ -21,6 +21,9 @@ class _OperatorDummy(_base._BaseNonparametricOperator):
     def evaluate(*args, **kwargs):
         return 0
 
+    def jacobian(*args, **kwargs):
+        return 0
+
 
 class TestAffineOperator:
     """Test opinf.core.operators._affine._AffineOperator."""

--- a/tests/core/operators/test_base.py
+++ b/tests/core/operators/test_base.py
@@ -18,7 +18,10 @@ class TestBaseNonparametricOperator:
             super().__init__(entries)
 
         def evaluate(*args, **kwargs):
-            pass
+            return 0
+
+        def jacobian(*args, **kwargs):
+            return 0
 
     class Dummy2(Dummy):
         """A distinct instantiable version of _BaseNonparametricOperator."""

--- a/tests/core/operators/test_interpolate.py
+++ b/tests/core/operators/test_interpolate.py
@@ -21,6 +21,9 @@ class _OperatorDummy(_base._BaseNonparametricOperator):
     def evaluate(*args, **kwargs):
         return 0
 
+    def jacobian(*args, **kwargs):
+        return 0
+
 
 class _InterpolatorDummy:
     """Dummy class for interpolator that obeys the following syntax.


### PR DESCRIPTION
This PR implements `jacobian()` methods for nonparametric operator classes and all ROM classes. The [Jacobian](https://en.wikipedia.org/wiki/Jacobian_matrix_and_determinant) of a function **f**: **R**^n -> **R**^m is an n x m matrix whose (_ij_)th entry is d fi / dxj. For quadratic **H**[**q** ⊗ **q**] and cubic **G**[**q** ⊗ **q** ⊗ **q**], we have

Jac(**H**)[**q**] = **H**[(**I** ⊗ **q**) + (**q** ⊗ **I**)]

Jac(**G**)[**q**] = **H**[(**I** ⊗ **q** ⊗ **q**) + (**q** ⊗ **I** ⊗ **q**) + (**q** ⊗ **q** ⊗ **I**)].

The implementation is efficient (no Kronecker products) but requires storing an `(r, r, r)` or `(r, r, r, r)` array.

The Jacobian is used automatically in `ContinuousOpInfROM.predict()` when the specified `method` of [`scipy.integrate.solve_ivp()`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.solve_ivp.html) requires it (BDF, Radau, LSODA). This can result in huge speedups for stiff problems.