### PR TITLE
Remove transformer attribute from bases, transformer load bug fixes

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade jupyter-book
+          python -m pip install --upgrade "jupyter-book>=0.14.0,<0.15.0"
       - name: Install package
         run: |
           python -m pip install --use-feature=in-tree-build .

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade jupyter-book
+          python -m pip install --upgrade "jupyter-book>=0.14.0,<0.15.0"
           python -m pip install --upgrade numpydoc
           python -m pip install --upgrade sphinx-design
           python -m pip install --upgrade sphinxcontrib-mermaid

--- a/Makefile
+++ b/Makefile
@@ -59,15 +59,16 @@ docs_all: install
 
 
 # Deployment (ADMINISTRATORS ONLY) --------------------------------------------
-deploy_package: test docs_all
+deploy_package: test
 	git checkout main
-	$(PYTHON) -m pip install build
+	$(PYTHON) -m pip install --upgrade build
+	$(PYTHON) -m pip install --upgrade twine
 	$(PYTHON) -m build --sdist --wheel
 	$(PYTHON) -m twine check dist/*
 	$(PYTHON) -m twine upload dist/*
 
 
-deploy_docs: docs_all
+deploy_docs: docs
 	$(PYTHON) -m pip install --upgrade ghp-import
 	git checkout main
 	ghp-import --remote upstream --no-jekyll --push --force --no-history docs/_build/html

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ docs: install
 
 
 docs_light:
+	$(PYTHON) -m pip install .
 	jupyter-book build --nitpick docs
 
 

--- a/docs/source/contributing/code_anatomy.md
+++ b/docs/source/contributing/code_anatomy.md
@@ -68,25 +68,9 @@ Lifting transformations should not be added to this package disguised as snapsho
 All basis classes must
 - Inherit from `pre.basis._base._BaseBasis`.
 - Accept `transformer` as an argument and call `_BaseBasis.__init__(self, transformer)` in the constructor.
-- Implement `fit()`, `encode()`, and `decode()`.
+- Implement `fit()`, `compress()`, and `decompress()`.
 
-Note that `project()` is **not** the same as `encode()`: `project(q) = decode(encode(q))`. This is a change from previous versions.
-
-This is not required by `_BaseBasis`, but all public basis classes have a `transformer` attribute that is set in the constructor.
-If present, the transformer should be trained at the beginning of the basis' `fit()` method and the data should be transformed before doing the basis computation. For example,
-
-```python
-class MyBasis:
-    def fit(self, states, r=None):
-        # First fit the transformer and transform the data.
-        if self.transformer is not None:
-            states = self.transformer.fit_transform(state)
-
-        # Then compute the basis entries.
-        self.entries = pod_basis(states, r)
-```
-
-If a basis has a `transformer`, `encode()` should `transform()` any input data before performing dimension reduction; similarly, `decode()` should `inverse_transform()` after undoing the dimension reduction.
+Note that `project()` is **not** the same as `compress()`: `project(q) = decompress(compress(q))`. This is a change from previous versions.
 
 Before implementing a new basis class, take a close look at `LinearBasis` and then `PODBasis`.
 
@@ -281,7 +265,7 @@ It handles
 - Dimensions (`n`, `r`, and `m`).
 - The basis $\mathbf{V}_{r}$ (`basis`).
 - Reduced-order operators (`c_`, `A_`, `H_`, `G_`, and `B_`).
-- Projection $\mathbf{q}\mapsto\widehat{\mathbf{q}} := \mathbf{V}_{r}^{\top}\mathbf{q}$ (`project()`) and reconstruction $\widehat{\mathbf{q}} \mapsto \mathbf{V}_{r}\widehat{\mathbf{q}}$ (`reconstruct()`).
+- Compression $\mathbf{q}\mapsto\widehat{\mathbf{q}} := \mathbf{V}_{r}^{\top}\mathbf{q}$ (`compress()`) and decompression $\widehat{\mathbf{q}} \mapsto \mathbf{V}_{r}\widehat{\mathbf{q}}$ (`decompress()`).
 - Evaluation of the right-hand side of the ROM (`evaluate()`) and its Jacobian (`jacobian()`).
 
 Classes that inherit from `_BaseROM` must (eventually) implement the following methods.
@@ -313,7 +297,7 @@ classDiagram
         n, m, r
         basis
         c_, A_, H_, G_, B_
-        project(), reconstruct()
+        compress(), decompress()
         evaluate(), jacobian()
     }
     class _NonparametricOpInfROM{
@@ -392,7 +376,7 @@ classDiagram
         n, m, r
         basis
         c_, A_, H_, G_, B_
-        project(), reconstruct()
+        compress(), decompress()
         evaluate(), jacobian()
     }
     class _BaseParametricROM{

--- a/docs/source/guides/basis.md
+++ b/docs/source/guides/basis.md
@@ -44,7 +44,7 @@ Through {eq}`eq-basis-basis-def`, the basis matrix is the link between the high-
 :width: 80 %
 :::
 
-:::::{note}
+<!-- :::::{note}
 If $\mathbf{V}_{r}\in\mathbb{R}^{n\times r}$ has orthogonal columns, the corresponding encoder is $\boldsymbol{\Gamma}^{*}(\mathbf{q}) = \mathbf{V}_{r}^{\mathsf{T}}\mathbf{q}$.
 
 :::{dropdown} Proof
@@ -109,7 +109,7 @@ $$
     = \widehat{\mathbf{q}}.
 $$
 
-:::::
+::::: -->
 
 <!-- :::{note}
 If the data is preprocessed, for example using `pre.SnapshotTransformer`, then the low-dimensional representation is slightly different from {eq}`eq-basis-basis-def`.

--- a/docs/source/guides/preprocessing.md
+++ b/docs/source/guides/preprocessing.md
@@ -14,12 +14,13 @@ which has high-dimensional state $\mathbf{q}(t) \in \mathbb{R}^{n}$.
 To achieve a computational speedup, we introduce a low-dimensional approximation
 
 $$
-    \mathbf{q}(t) \approx \boldsymbol{\Gamma}(\widehat{\mathbf{q}}(t)),
+    \mathbf{q}(t)
+    \approx \boldsymbol{\Gamma}(\widehat{\mathbf{q}}(t)),
 $$ (eq-preproc-approx)
 
 where $\widehat{\mathbf{q}}(t)\in\mathbb{R}^{r}$ and $r \ll n$.
 Operator Inference learns a reduced-order model that determines the evolution of the latent coordinates $\widehat{\mathbf{q}}(t)$.
-This chapter discusses modeling choices for $\boldsymbol{\Gamma}$, the mapping that bridges the latent coordinates and the original state space.
+This chapter discusses choices for $\boldsymbol{\Gamma}$, the mapping that bridges the latent coordinates and the original state space.
 We approach this in two stages.
 
 **Data scaling.**
@@ -30,54 +31,9 @@ Common preprocessing steps include
 3. Scaling / nondimensionalizing the variables represented in the state.
 
 **Data compression.**
-Once the data is properly normalized, a dimensionality reduction technique encodes the data in a latent low-dimensional coordinate system.
+Once the data is properly normalized, a dimensionality reduction technique compresses the data to a latent low-dimensional coordinate system.
 
 Proper preprocessing can improve the dimensionality reduction, promote stability in the inference of the reduced-order operators, and increase the stability and accuracy of the resulting reduced-order model.
-
-:::::{admonition} Terminology
-:class: important
-The mapping $\boldsymbol{\Gamma} : \mathbb{R}^{r} \to \mathbb{R}^{n}$ is called the _decoder_.
-The corresponding _encoder_ $\boldsymbol{\Gamma}^{*} : \mathbb{R}^{n} \to \mathbb{R}^{r}$ is defined by the minimization
-
-$$
-    \boldsymbol{\Gamma}^{*}(\mathbf{q})
-    = \underset{\widehat{\mathbf{q}}\in\mathbb{R}^{r}}{\textrm{arg min}}\left\|
-        \mathbf{q} - \boldsymbol{\boldsymbol{\Gamma}}(\widehat{\mathbf{q}})
-    \right\|.
-$$
-
-In other words, the encoding of state vector $\mathbf{q} \in \mathbb{R}^{n}$ is the low-dimensional vector $\widehat{\mathbf{q}}\in\mathbb{R}^{r}$ such that the approximation {eq}`eq-preproc-approx` is as exact as possible.
-The mapping from $\mathbf{q}$ to its best approximation in terms of $\boldsymbol{\Gamma}$ is called _projection_, and the quantity
-
-$$
-    \left\|\mathbf{q} - \boldsymbol{\Gamma}(\boldsymbol{\Gamma}^{*}(\mathbf{q}))\right\|
-$$
-
-is called the _projection error_ of $\mathbf{q}$ induced by $\boldsymbol{\Gamma}$.
-
-::::{grid}
-:gutter: 3
-:margin: 2 2 0 0
-
-:::{grid-item-card}
-`encode(state)`
-^^^
-$\mathbf{q} \mapsto \boldsymbol{\Gamma}^{*}(\mathbf{q})$
-:::
-
-:::{grid-item-card}
-`decode(state_)`
-^^^
-$\widehat{\mathbf{q}} \to \boldsymbol{\Gamma}(\widehat{\mathbf{q}})$
-:::
-
-:::{grid-item-card}
-`project(state)`
-^^^
-$\mathbf{q}\mapsto \boldsymbol{\Gamma}(\boldsymbol{\Gamma}^{*}(\mathbf{q}))$
-:::
-::::
-:::::
 
 ```{tableofcontents}
 ```

--- a/docs/source/guides/romclasses.md
+++ b/docs/source/guides/romclasses.md
@@ -251,12 +251,12 @@ $$
 
 All ROM classes have the following methods.
 
-### Encoding and Decoding
+### Dimensionality Reduction
 
-The `encode()` method maps a state quantity from the high-dimensional space $\mathbb{R}^{n}$ to the low-dimensional space $\mathbb{R}^{r}$.
-Conversely, `decode()` maps from $\mathbb{R}^{r}$ to $\mathbb{R}^{n}$.
-<!-- These methods are not quite inverses: the results of `decode()` are restricted to the portion of $\mathbb{R}^{n}$ that can be represented through the underlying basis. -->
-These methods wrap the `encode()` and `decode()` methods of the `basis` attribute; see [Preprocessing](sec-preprocessing) and [Basis Computation](sec-basis-computation) for more details.
+The `compress()` method maps a state quantity from the high-dimensional space $\mathbb{R}^{n}$ to the low-dimensional space $\mathbb{R}^{r}$.
+Conversely, `decompress()` maps from $\mathbb{R}^{r}$ to $\mathbb{R}^{n}$.
+<!-- These methods are not quite inverses: the results of `decompress()` are restricted to the portion of $\mathbb{R}^{n}$ that can be represented through the underlying basis. -->
+These methods wrap the `compress()` and `decompress()` methods of the `basis` attribute; see [Preprocessing](sec-preprocessing) and [Basis Computation](sec-basis-computation) for more details.
 
 ### Training
 
@@ -319,8 +319,8 @@ Several programming languages support HDF5 format (MATLAB, C, C++, etc.), making
 
 | Method | Description |
 | :----- | :---------- |
-| `project()` | Map high-dimensional states to their low-dimensional coordinates |
-| `reconstruct()` | Use low-dimensional coordinates to construct a high-dimensional state |
+| `compress()` | Map high-dimensional states to their low-dimensional coordinates |
+| `decompress()` | Use low-dimensional coordinates to construct a high-dimensional state |
 | `fit()` | Use training data to infer the operators defining the ROM |
 | `evaluate()` | Evaluate the reduced-order model for a given state / input |
 | `predict()` | Solve the reduced-order model |
@@ -395,7 +395,7 @@ evaluate(self, t, state_, input_func=None)
 The `predict()` method of `ContinuousOpInfROM` wraps [`scpiy.integrate.solve_ivp()`](https://docs.scipy.org/doc/scipy/reference/integrate.html) to solve the reduced-order model over a given time domain.
 
 ```python
-predict(self, state0, t, input_func=None, reconstruct=True, **options)
+predict(self, state0, t, input_func=None, decompress=True, **options)
 ```
 
 | Argument | Type | Description |
@@ -403,7 +403,7 @@ predict(self, state0, t, input_func=None, reconstruct=True, **options)
 | `state0` | `(n,) or (r,) ndarray` | Initial state vector $\mathbf{q}(0)\in\mathbb{R}^{n}$ or $\widehat{\mathbf{q}}(0)\in\mathbb{R}^{r}$ |
 | `t` | `(nt,) ndarray` | Time domain over which to integrate the ROM |
 | `input_func` | `callable` | Mapping $t \mapsto \mathbf{u}(t)$ |
-| `reconstruct` | `bool` | If True and the `basis` is not `None`, decode the results to the $n$-dimensional state space |
+| `decompress` | `bool` | If True and the `basis` is not `None`, reconstruct the results in the $n$-dimensional state space |
 | `**options` | | Additional arguments for `scipy.integrate.solve_ivp()` |
 
 <!-- TODO: implement common solvers and document here. -->
@@ -468,7 +468,7 @@ The `predict()` method of `DiscreteOpInfROM` iterates the system to solve the re
 Unlike the continuous-time case, there are no choices to make about what scheme to use to solve the problem: the solution iteration is explicitly described by the reduced-order model.
 
 ```python
-predict(self, state0, niters, inputs=None, reconstruct=True)
+predict(self, state0, niters, inputs=None, decompress=True)
 ```
 
 | Argument | Type | Description |
@@ -476,7 +476,7 @@ predict(self, state0, niters, inputs=None, reconstruct=True)
 | `state0` | `(n,) or (r,) ndarray` | Initial state vector $\mathbf{q}_{0}\in\mathbb{R}^{n}$ or $\widehat{\mathbf{q}}_{0}\in\mathbb{R}^{r}$ |
 | `niters` | `int` | Number of times to step the system forward |
 | `inputs` | `(m, niters-1) ndarray` | Inputs $\mathbf{u}_{j}$ for the next `niters-1` time steps |
-| `reconstruct` | `bool` | If True and the `basis` is not `None`, decode the results to the $n$-dimensional state space |
+| `decompress` | `bool` | If True and the `basis` is not `None`, reconstruct the results in the $n$-dimensional state space |
 
 <!-- TODO: implement common solvers and document here. -->
 

--- a/docs/source/tutorials/basics.ipynb
+++ b/docs/source/tutorials/basics.ipynb
@@ -469,7 +469,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -492,7 +491,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -533,7 +531,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -586,7 +583,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -627,7 +623,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -654,7 +649,7 @@
    "source": [
     ":::{tip}\n",
     "The finite difference approximation for $\\dot{\\mathbf{Q}}$ commutes with the encoding in a low-dimensional subspace, that is, $\\mathbf{V}_{r}^\\top\\frac{\\text{d}}{\\text{d}t}\\left[\\mathbf{Q}\\right] = \\frac{\\text{d}}{\\text{d}t}\\left[\\mathbf{V}_{r}^{\\top}\\mathbf{Q}\\right]$.\n",
-    "To save memory, the snapshot matrix may be encoded first, and the time derivatives can be calculated from the encoded snapshots.\n",
+    "To save memory, the snapshot matrix may be compressed first, and the time derivatives can be calculated from the compressed snapshots.\n",
     "The ROM classes in the next section accept both full-order ($n \\times k$) or reduced-order ($r\\times k$) snapshot and time derivative matrices as training data.\n",
     ":::"
    ]
@@ -665,8 +660,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Q_ = Vr.T @ Q                                   # Encode the state snapshots.\n",
-    "Qdot_ = opinf.pre.ddt_uniform(Q_, dt, order=6)  # Estimate time derivatives of encoded states.\n",
+    "Q_ = Vr.T @ Q                                   # Compress the state snapshots.\n",
+    "Qdot_ = opinf.pre.ddt_uniform(Q_, dt, order=6)  # Estimate time derivatives of compressed states.\n",
     "\n",
     "np.allclose(Vr.T @ Qdot2, Qdot_)                # Same as encoding the full-order time derivatives."
    ]
@@ -679,7 +674,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -723,7 +717,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -806,7 +799,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -866,12 +858,11 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Once the model is fit, we may simulate the ROM with the [**predict()**](opinf.ContinuousOpInfROM.predict) method, which wraps `scipy.integrate.solve_ivp()`.\n",
-    "This method takes an initial condition from the original space $\\mathbb{R}^n$, encodes it in $\\mathbb{R}^r$, simulates the ROM in $\\mathbb{R}^r$, and decodes the results to $\\mathbb{R}^n$."
+    "This method takes an initial condition from the original space $\\mathbb{R}^n$, encodes it in $\\mathbb{R}^r$, simulates the ROM in $\\mathbb{R}^r$, and reconstructs the results in $\\mathbb{R}^n$."
    ]
   },
   {
@@ -885,7 +876,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -933,7 +923,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -953,7 +942,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/source/tutorials/heat_equation.ipynb
+++ b/docs/source/tutorials/heat_equation.ipynb
@@ -537,7 +537,7 @@
    "metadata": {},
    "source": [
     "Like the FOM, we integrate the learned ROM using the implicit Euler method, using the reduced-order operators $\\widehat{\\mathbf{A}}$ and $\\widehat{\\mathbf{B}}$ and the initial condition $\\widehat{\\mathbf{q}}_{0} = \\mathbf{V}^{\\mathsf{T}}\\mathbf{q}_{0}$.\n",
-    "The resulting low-dimensional state vectors are decoded back to the full-dimensional space via $\\mathbf{q}(t) = \\mathbf{V}_{r}\\widehat{\\mathbf{q}}(t)$."
+    "The resulting low-dimensional state vectors are reconstructed in the full-dimensional space via $\\mathbf{q}(t) = \\mathbf{V}_{r}\\widehat{\\mathbf{q}}(t)$."
    ]
   },
   {
@@ -547,10 +547,10 @@
    "outputs": [],
    "source": [
     "# Express the initial condition in the coordinates of the basis.\n",
-    "q0_ = basis.encode(q0)\n",
+    "q0_ = basis.compress(q0)\n",
     "\n",
     "# Solve the reduced-order model using Implicit Euler.\n",
-    "Q_ROM = basis.decode(implicit_euler(t, q0_, rom.A_.entries, rom.B_.entries, U_all))"
+    "Q_ROM = basis.decompress(implicit_euler(t, q0_, rom.A_.entries, rom.B_.entries, U_all))"
    ]
   },
   {
@@ -707,8 +707,8 @@
     "Vr = basis.entries\n",
     "Atilde = Vr.T @ A @ Vr\n",
     "Btilde = Vr.T @ B\n",
-    "q0_ = basis.encode(q0)\n",
-    "Q_ROM_intrusive = basis.decode(implicit_euler(t, q0_, Atilde, Btilde, U_all))"
+    "q0_ = basis.compress(q0)\n",
+    "Q_ROM_intrusive = basis.decompress(implicit_euler(t, q0_, Atilde, Btilde, U_all))"
    ]
   },
   {
@@ -728,7 +728,7 @@
     ">>> np.all(rom_intrusive.B_.entries[:, 0] == Btilde)\n",
     "True\n",
     "\n",
-    ">>> Q_ROM_intrusive = basis.decode(implicit_euler(t, q0_, rom_intrusive.A_.entries, rom_intrusive.B_.entries, U_all))\n",
+    ">>> Q_ROM_intrusive = basis.decompress(implicit_euler(t, q0_, rom_intrusive.A_.entries, rom_intrusive.B_.entries, U_all))\n",
     "```\n",
     "\n",
     "If, for example, only the full-order operator $\\mathbf{B}$ were known (but not $\\mathbf{A}$), we can learn $\\widehat{\\mathbf{A}}$ through OpInf and $\\widehat{\\mathbf{B}}$ through intrusive projection:\n",
@@ -799,20 +799,20 @@
     "def run_trial(r):\n",
     "    \"\"\"Do OpInf / intrusive ROM prediction with r basis vectors.\"\"\"\n",
     "    basis.r = r\n",
-    "    q0_ = basis.encode(q0)\n",
+    "    q0_ = basis.compress(q0)\n",
     "\n",
     "    # Construct and simulate the intrusive ROM.\n",
     "    rom_intrusive = opinf.ContinuousOpInfROM(\"AB\").fit(basis, None, None,\n",
     "                                                       known_operators={\"A\":A, \"B\":B})\n",
-    "    Q_ROM_intrusive = basis.decode(implicit_euler(t, q0_,\n",
-    "                                                  rom_intrusive.A_.entries,\n",
-    "                                                  rom_intrusive.B_.entries, U_all))\n",
+    "    Q_ROM_intrusive = basis.decompress(implicit_euler(t, q0_,\n",
+    "                                                      rom_intrusive.A_.entries,\n",
+    "                                                      rom_intrusive.B_.entries, U_all))\n",
     "\n",
     "    # Construct and simulate the operator inference ROM.\n",
     "    rom_opinf = opinf.ContinuousOpInfROM(\"AB\").fit(basis, Q_train, Qdot_train, U_train)\n",
-    "    Q_ROM_opinf = basis.decode(implicit_euler(t, q0_,\n",
-    "                                              rom_opinf.A_.entries,\n",
-    "                                              rom_opinf.B_.entries, U_all))\n",
+    "    Q_ROM_opinf = basis.decompress(implicit_euler(t, q0_,\n",
+    "                                                  rom_opinf.A_.entries,\n",
+    "                                                  rom_opinf.B_.entries, U_all))\n",
     "\n",
     "    # Calculate errors.\n",
     "    projection_error = basis.projection_error(Q_all, relative=True)\n",
@@ -1033,7 +1033,7 @@
     "print(basis)\n",
     "\n",
     "# Express the initial condition in the coordinates of the new basis.\n",
-    "q0_ = basis.encode(q0)"
+    "q0_ = basis.compress(q0)"
    ]
   },
   {
@@ -1099,7 +1099,7 @@
    "source": [
     "# Test ROM accuracy on the training inputs.\n",
     "Qs_ROM_train = [\n",
-    "    basis.decode(implicit_euler(t, q0_, rom.A_.entries, rom.B_.entries, U))\n",
+    "    basis.decompress(implicit_euler(t, q0_, rom.A_.entries, rom.B_.entries, U))\n",
     "    for U in Us_all_train\n",
     "]\n",
     "plot_errors_over_time_inputs(Qs_ROM_train, Qs_all_train)\n",
@@ -1107,7 +1107,7 @@
     "\n",
     "# Test ROM accuracy on the testing inputs.\n",
     "Qs_ROM_test = [\n",
-    "    basis.decode(implicit_euler(t, q0_, rom.A_.entries, rom.B_.entries, U))\n",
+    "    basis.decompress(implicit_euler(t, q0_, rom.A_.entries, rom.B_.entries, U))\n",
     "    for U in Us_all_test\n",
     "]\n",
     "plot_errors_over_time_inputs(Qs_ROM_test, Qs_all_test,\n",
@@ -1132,7 +1132,7 @@
     "def run_trial_inputs(r):\n",
     "    \"\"\"Do OpInf / intrusive ROM prediction with r basis vectors.\"\"\"\n",
     "    basis.r = r\n",
-    "    q0_ = basis.encode(q0)\n",
+    "    q0_ = basis.compress(q0)\n",
     "\n",
     "    # Construct the intrusive ROM.\n",
     "    rom_intrusive = opinf.ContinuousOpInfROM(\"AB\").fit(basis, None, None,\n",
@@ -1147,14 +1147,14 @@
     "    for Q, U in zip(Qs_all_test, Us_all_test):\n",
     "\n",
     "        # Simulate the intrusive ROM for this testing input.\n",
-    "        Q_ROM_intrusive = basis.decode(implicit_euler(t, q0_,\n",
-    "                                                      rom_intrusive.A_.entries,\n",
-    "                                                      rom_intrusive.B_.entries, U))\n",
+    "        Q_ROM_intrusive = basis.decompress(implicit_euler(t, q0_,\n",
+    "                                                          rom_intrusive.A_.entries,\n",
+    "                                                          rom_intrusive.B_.entries, U))\n",
     "\n",
     "        # Simulate the operator inference ROM for this testing input.\n",
-    "        Q_ROM_opinf = basis.decode(implicit_euler(t, q0_,\n",
-    "                                                  rom_opinf.A_.entries,\n",
-    "                                                  rom_opinf.B_.entries, U))\n",
+    "        Q_ROM_opinf = basis.decompress(implicit_euler(t, q0_,\n",
+    "                                                      rom_opinf.A_.entries,\n",
+    "                                                      rom_opinf.B_.entries, U))\n",
     "\n",
     "        # Calculate errors.\n",
     "        projection_error += basis.projection_error(Q, relative=True)\n",
@@ -1489,7 +1489,7 @@
     "def run_trial_parametric(r):\n",
     "    \"\"\"Do OpInf / intrusive ROM prediction with r basis vectors.\"\"\"\n",
     "    basis.r = r\n",
-    "    q0_ = basis.encode(q0)\n",
+    "    q0_ = basis.compress(q0)\n",
     "\n",
     "    # Compute the intrusive ROM.\n",
     "    rom_intrusive = opinf.InterpolatedContinuousOpInfROM(\"AB\")\n",
@@ -1512,11 +1512,11 @@
     "\n",
     "        # Simulate the intrusive ROM at this parameter value.\n",
     "        romµ = rom_intrusive(µ)\n",
-    "        Q_ROM_intrusive = basis.decode(implicit_euler(t, q0_, romµ.A_.entries, romµ.B_.entries, U_all))\n",
+    "        Q_ROM_intrusive = basis.decompress(implicit_euler(t, q0_, romµ.A_.entries, romµ.B_.entries, U_all))\n",
     "\n",
     "        # Simulate the interpolating OpInf ROM at this parameter value.\n",
     "        romµ = rom_opinf(µ)\n",
-    "        Q_ROM_opinf = basis.decode(implicit_euler(t, q0_, romµ.A_.entries, romµ.B_.entries, U_all))\n",
+    "        Q_ROM_opinf = basis.decompress(implicit_euler(t, q0_, romµ.A_.entries, romµ.B_.entries, U_all))\n",
     "\n",
     "        # Calculate errors.\n",
     "        projection_error += basis.projection_error(Q_FOM, relative=True)\n",

--- a/docs/templates/autosummary/class.rst
+++ b/docs/templates/autosummary/class.rst
@@ -7,12 +7,10 @@
    :no-inherited-members:
    :no-special-members:
 
-   .. automethod:: __init__
-
-   {% block attributes %}
+   {% block properties %}
    {% if attributes %}
 
-   **Attributes**
+   **Properties**
 
    .. autosummary::
    {% for item in all_attributes %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ tests = [
     "flake8>=3.9.0",
 ]
 docs = [
-    "jupyter-book>=0.13.1",
+    "jupyter-book>=0.14.0,<0.15.0",
     "numpydoc>=1.2",
     "sphinx-design>=0.1.0",
     "sphinxcontrib-mermaid>=0.7.1",

--- a/src/opinf/__init__.py
+++ b/src/opinf/__init__.py
@@ -7,7 +7,7 @@ GitHub:
     https://github.com/Willcox-Research-Group/rom-operator-inference-Python3
 """
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"
 
 from .core import *
 from . import errors, lstsq, pre, post, utils

--- a/src/opinf/core/_base.py
+++ b/src/opinf/core/_base.py
@@ -463,7 +463,7 @@ class _BaseROM(abc.ABC):
         # Save keys of known operators.
         self._projected_operators_ = ''.join(known_operators.keys())
 
-    def encode(self, state, label="argument"):
+    def compress(self, state, label="argument"):
         """Map high-dimensional states to low-dimensional latent coordinates.
 
         Parameters
@@ -485,9 +485,11 @@ class _BaseROM(abc.ABC):
             if self.basis is None:
                 raise AttributeError("basis not set")
             raise ValueError(f"{label} not aligned with basis")
-        return self.basis.encode(state) if state.shape[0] == self.n else state
+        if state.shape[0] == self.n:
+            return self.basis.compress(state)
+        return state
 
-    def decode(self, state_, label="argument"):
+    def decompress(self, state_, label="argument"):
         """Map low-dimensional latent coordinates to high-dimensional states.
 
         Parameters
@@ -506,27 +508,7 @@ class _BaseROM(abc.ABC):
             raise AttributeError("basis not set")
         if state_.shape[0] != self.r:
             raise ValueError(f"{label} not aligned with basis")
-        return self.basis.decode(state_)
-
-    # def project(self, state):
-    #     """Project high-dimensional states to the subspace that can be
-    #     represented by the basis by encoding the state in low-dimensional
-    #     latent coordinates, then decoding those coordinates:
-    #     project(Q) = decode(encode(Q)).
-    #
-    #     Parameters
-    #     ----------
-    #     state : (n, ...) ndarray
-    #         High-dimensional state vector or a collection of these.
-    #
-    #     Returns
-    #     -------
-    #     state_projected : (n, ...) ndarray
-    #         High-dimensional state vector, or a collection of k such vectors
-    #         organized as the columns of a matrix, projected to the range of
-    #         the basis.
-    #     """
-    #     return self.decode(self.encode(state))
+        return self.basis.decompress(state_)
 
     # ROM evaluation ----------------------------------------------------------
     def evaluate(self, state_, input_=None):

--- a/src/opinf/core/interpolate/_public.py
+++ b/src/opinf/core/interpolate/_public.py
@@ -298,7 +298,7 @@ class InterpolatedDiscreteOpInfROM(_InterpolatedOpInfROM):
                                          solvers=solvers)
 
     def predict(self, parameter, state0, niters, inputs=None,
-                decode=True):
+                decompress=True):
         """Step forward the ROM `niters` steps at the given parameter value.
 
         Parameters
@@ -316,7 +316,7 @@ class InterpolatedDiscreteOpInfROM(_InterpolatedOpInfROM):
             >>> states[:, 1] = F(state0, inputs[:, 0])
             >>> states[:, 2] = F(states[:, 1], inputs[:, 1])
             ...
-        decode : bool
+        decompress : bool
             If True and the basis is not None, reconstruct the solutions
             in the original n-dimensional state space.
 
@@ -324,13 +324,13 @@ class InterpolatedDiscreteOpInfROM(_InterpolatedOpInfROM):
         -------
         states : (n, niters) or (r, niters) ndarray
             Approximate solution to the system, including the given
-            initial condition. If the basis exists and decode=True,
+            initial condition. If the basis exists and decompress=True,
             return solutions in the full n-dimensional state space (n rows);
             otherwise, return reduced-order state solution (r rows).
         """
         return _InterpolatedOpInfROM.predict(self, parameter,
                                              state0, niters, inputs,
-                                             decode)
+                                             decompress)
 
 
 class InterpolatedContinuousOpInfROM(_InterpolatedOpInfROM):
@@ -466,7 +466,7 @@ class InterpolatedContinuousOpInfROM(_InterpolatedOpInfROM):
             known_operators=known_operators, solvers=solvers)
 
     def predict(self, parameter, state0, t, input_func=None,
-                decode=True, **options):
+                decompress=True, **options):
         """Simulate the learned ROM at the given parameter value with
         scipy.integrate.solve_ivp().
 
@@ -483,7 +483,7 @@ class InterpolatedContinuousOpInfROM(_InterpolatedOpInfROM):
             Input as a function of time (preferred) or the input at the
             times `t`. If given as an array, cubic spline interpolation
             on the known data points is used as needed.
-        decode : bool
+        decompress : bool
             If True and the basis is not None, reconstruct the solutions
             in the original n-dimensional state space.
         options
@@ -507,7 +507,7 @@ class InterpolatedContinuousOpInfROM(_InterpolatedOpInfROM):
         -------
         states : (n, nt) or (r, nt) ndarray
             Approximate solution to the system over the time domain `t`.
-            If the basis exists and decode=True, return solutions in the
+            If the basis exists and decompress=True, return solutions in the
             original n-dimensional state space (n rows); otherwise, return
             reduced-order state solutions (r rows).
             A more detailed report on the integration results is stored as
@@ -515,4 +515,4 @@ class InterpolatedContinuousOpInfROM(_InterpolatedOpInfROM):
         """
         return _InterpolatedOpInfROM.predict(self, parameter,
                                              state0, t, input_func,
-                                             decode, **options)
+                                             decompress, **options)

--- a/src/opinf/core/nonparametric/_base.py
+++ b/src/opinf/core/nonparametric/_base.py
@@ -154,8 +154,8 @@ class _NonparametricOpInfROM(_BaseROM):
         self._check_training_data_shapes(to_check)
 
         # Encode states and lhs in the reduced subspace (if needed).
-        states_ = self.encode(states, "states")
-        lhs_ = self.encode(lhs, self._LHS_ARGNAME)
+        states_ = self.compress(states, "states")
+        lhs_ = self.compress(lhs, self._LHS_ARGNAME)
 
         # Subtract known data from the lhs data.
         for key in self._projected_operators_:

--- a/src/opinf/core/nonparametric/_public.py
+++ b/src/opinf/core/nonparametric/_public.py
@@ -249,7 +249,7 @@ class DiscreteOpInfROM(_NonparametricOpInfROM):
             self, basis, states, nextstates, inputs=inputs,
             known_operators=known_operators, solver=solver)
 
-    def predict(self, state0, niters, inputs=None, decode=True):
+    def predict(self, state0, niters, inputs=None, decompress=True):
         """Step forward the learned ROM `niters` steps.
 
         Parameters
@@ -265,7 +265,7 @@ class DiscreteOpInfROM(_NonparametricOpInfROM):
             >>> states[:, 1] = F(state0, inputs[:, 0])
             >>> states[:, 2] = F(states[:, 1], inputs[:, 1])
             ...
-        decode : bool
+        decompress : bool
             If True and the basis is not None, reconstruct the solutions in
             the original n-dimensional state space.
 
@@ -273,7 +273,7 @@ class DiscreteOpInfROM(_NonparametricOpInfROM):
         -------
         states : (n, niters) or (r, niters) ndarray
             Approximate solution to the system, including the given
-            initial condition. If the basis exists and decode=True,
+            initial condition. If the basis exists and decompress=True,
             return solutions in the full n-dimensional state space (n rows);
             otherwise, return reduced-order state solution (r rows).
         """
@@ -281,7 +281,7 @@ class DiscreteOpInfROM(_NonparametricOpInfROM):
 
         # Process inputs and project initial conditions if needed.
         self._check_inputargs(inputs, "inputs")
-        state0_ = self.encode(state0, "state0")
+        state0_ = self.compress(state0, "state0")
 
         # Verify iteration argument.
         if not isinstance(niters, int) or niters < 1:
@@ -307,8 +307,8 @@ class DiscreteOpInfROM(_NonparametricOpInfROM):
                 states_[:, j+1] = self.evaluate(states_[:, j])
 
         # Return state results.
-        if decode and (self.basis is not None):
-            return self.decode(states_)
+        if decompress and (self.basis is not None):
+            return self.basis.decompress(states_)
         return states_
 
 
@@ -446,7 +446,7 @@ class ContinuousOpInfROM(_NonparametricOpInfROM):
             self, basis, states, ddts, inputs=inputs,
             known_operators=known_operators, solver=solver)
 
-    def predict(self, state0, t, input_func=None, decode=True, **options):
+    def predict(self, state0, t, input_func=None, decompress=True, **options):
         """Simulate the learned ROM with scipy.integrate.solve_ivp().
 
         Parameters
@@ -460,7 +460,7 @@ class ContinuousOpInfROM(_NonparametricOpInfROM):
             Input as a function of time (preferred) or the input at the
             times `t`. If given as an array, cubic spline interpolation
             on the known data points is used as needed.
-        decode : bool
+        decompress : bool
             If True and the basis is not None, reconstruct the solutions
             in the original n-dimensional state space.
         options
@@ -484,7 +484,7 @@ class ContinuousOpInfROM(_NonparametricOpInfROM):
         -------
         states : (n, nt) or (r, nt) ndarray
             Approximate solution to the system over the time domain `t`.
-            If the basis exists and decode=True, return solutions in the
+            If the basis exists and decompress=True, return solutions in the
             original n-dimensional state space (n rows); otherwise, return
             reduced-order state solutions (r rows).
             A more detailed report on the integration results is stored as
@@ -494,7 +494,7 @@ class ContinuousOpInfROM(_NonparametricOpInfROM):
 
         # Process inputs and project initial conditions if needed.
         self._check_inputargs(input_func, "input_func")
-        state0_ = self.encode(state0, "state0")
+        state0_ = self.compress(state0, "state0")
 
         # Verify time domain.
         if t.ndim != 1:
@@ -542,6 +542,6 @@ class ContinuousOpInfROM(_NonparametricOpInfROM):
 
         # Return state results.
         self.predict_result_ = out
-        if decode and (self.basis is not None):
-            return self.decode(out.y)
+        if decompress and (self.basis is not None):
+            return self.basis.decompress(out.y)
         return out.y

--- a/src/opinf/pre/_finite_difference.py
+++ b/src/opinf/pre/_finite_difference.py
@@ -91,6 +91,7 @@ def ddt_uniform(states, dt, order=2):
                          - Q[:, 4:])/(12*dt)
 
         # Forward / backward differences on the front / end.
+        # TODO: don't use fully forward / fully backward for interior points.
         for j in range(2):
             ddts[:, j] = _fwd4(Q[:, j:j+5].T, dt)                 # Forward
             ddts[:, -j-1] = -_fwd4(Q[:, -j-5:k-j].T[::-1], dt)    # Backward
@@ -101,6 +102,7 @@ def ddt_uniform(states, dt, order=2):
                          - 45*Q[:, 2:-4] + 45*Q[:, 4:-2]
                          - 9*Q[:, 5:-1] + Q[:, 6:]) / (60*dt)
 
+        # TODO: don't use fully forward / fully backward for interior points.
         # Forward / backward differences on the front / end.
         for j in range(3):
             ddts[:, j] = _fwd6(Q[:, j:j+7].T, dt)                 # Forward

--- a/src/opinf/pre/basis/_base.py
+++ b/src/opinf/pre/basis/_base.py
@@ -57,47 +57,51 @@ class _BaseBasis(abc.ABC):
 
     # Projection --------------------------------------------------------------
     def project(self, state):
-        """Project a high-dimensional state vector to the subset of the high-
-        dimensional space that can be represented by the basis by expressing
-        the state in low-dimensional latent coordinates, then decoding those
-        coordinates: `project(`Q`)` = `decompress(compress(`Q`))`.
+        """Project a high-dimensional state vector to the subset of the
+        high-dimensional space that can be represented by the basis by
+        1) expressing the state in low-dimensional latent coordinates, then 2)
+        reconstructing the high-dimensional state corresponding to those
+        coordinates. That is, ``project(Q)`` is equivalent to
+        ``decompress(compress(Q))``.
 
         Parameters
         ----------
         state : (n,) or (n, k) ndarray
-            High-dimensional state vector, or a collection of k such vectors
+            High-dimensional state vector, or a collection of `k` such vectors
             organized as the columns of a matrix.
 
         Returns
         -------
         state_projected : (n,) or (n, k) ndarray
-            High-dimensional state vector, or a collection of k such vectors
+            High-dimensional state vector, or a collection of `k` such vectors
             organized as the columns of a matrix, projected to the basis range.
         """
         return self.decompress(self.compress(state))
 
     def projection_error(self, state, relative=True):
-        """Compute the error of the basis representation of a state or states:
+        r"""Compute the error of the basis representation of a state or states:
+        ``|| state - project(state) || / || state ||``.
 
-            err_absolute = || state - project(state) ||
-            err_relative = || state - project(state) || / || state ||
-
-        If `state` is one-dimensional then || . || is the vector 2-norm.
-        If `state` is two-dimensional then || . || is the Frobenius norm.
-        See scipy.linalg.norm().
+        If ``state`` is one-dimensional then :math:`||\cdot||` is the vector
+        2-norm. If ``state`` is two-dimensional then :math:`||\cdot||` is the
+        Frobenius norm.
 
         Parameters
         ----------
         state : (n,) or (n, k) ndarray
-            High-dimensional state vector, or a collection of k such vectors
+            High-dimensional state vector, or a collection of `k` such vectors
             organized as the columns of a matrix.
         relative : bool
-            If True, normalize the error by the norm of the original state.
+            If True, return the relative error
+            ``|| state - project(state) || / || state ||``.
+            If False, return the absolute error
+            ``|| state - project(state) ||``.
 
         Returns
         -------
-            Relative error of the projection (relative=True) or
-            absolute error of the projection (relative=False).
+        float
+            Relative error of the projection (``relative=True``) or
+            absolute error of the projection (``relative=False``).
         """
         diff = la.norm(state - self.project(state))
         if relative:

--- a/src/opinf/pre/basis/_base.py
+++ b/src/opinf/pre/basis/_base.py
@@ -14,9 +14,9 @@ class _BaseBasis(abc.ABC):
         """Construct the basis."""
         raise NotImplementedError
 
-    # Encoding / Decoding -----------------------------------------------------
+    # Dimension reduction -----------------------------------------------------
     @abc.abstractmethod
-    def encode(self, state):                                # pragma: no cover
+    def compress(self, state):                              # pragma: no cover
         """Map high-dimensional states to low-dimensional latent coordinates.
 
         Parameters
@@ -34,7 +34,7 @@ class _BaseBasis(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def decode(self, state_):                               # pragma: no cover
+    def decompress(self, state_):                           # pragma: no cover
         """Map low-dimensional latent coordinates to high-dimensional states.
 
         Parameters
@@ -54,9 +54,9 @@ class _BaseBasis(abc.ABC):
     # Projection --------------------------------------------------------------
     def project(self, state):
         """Project a high-dimensional state vector to the subset of the high-
-        dimensional space that can be represented by the basis by encoding the
-        state in low-dimensional latent coordinates, then decoding those
-        coordinates: project(Q) = decode(encode(Q)).
+        dimensional space that can be represented by the basis by expressing
+        the state in low-dimensional latent coordinates, then decoding those
+        coordinates: `project(`Q`)` = `decompress(compress(`Q`))`.
 
         Parameters
         ----------
@@ -70,7 +70,7 @@ class _BaseBasis(abc.ABC):
             High-dimensional state vector, or a collection of k such vectors
             organized as the columns of a matrix, projected to the basis range.
         """
-        return self.decode(self.encode(state))
+        return self.decompress(self.compress(state))
 
     def projection_error(self, state, relative=True):
         """Compute the error of the basis representation of a state or states:

--- a/src/opinf/pre/basis/_base.py
+++ b/src/opinf/pre/basis/_base.py
@@ -34,7 +34,7 @@ class _BaseBasis(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def decompress(self, state_):                           # pragma: no cover
+    def decompress(self, state_, locs=None):                # pragma: no cover
         """Map low-dimensional latent coordinates to high-dimensional states.
 
         Parameters
@@ -42,12 +42,16 @@ class _BaseBasis(abc.ABC):
         state_ : (r,) or (r, k) ndarray
             Low-dimensional latent coordinate vector, or a collection of k
             such vectors organized as the columns of a matrix.
+        locs : slice or (p,) ndarray of integers or None
+            If given, return the reconstructed state at only the specified
+            locations (indices).
 
         Returns
         -------
         state : (n,) or (n, k) ndarray
             High-dimensional state vector, or a collection of k such vectors
-            organized as the columns of a matrix.
+            organized as the columns of a matrix. If `locs` is given, only
+            the specified coordinates are returned.
         """
         raise NotImplementedError
 

--- a/src/opinf/pre/basis/_base.py
+++ b/src/opinf/pre/basis/_base.py
@@ -4,27 +4,9 @@
 import abc
 import scipy.linalg as la
 
-from ..transform._base import _check_is_transformer
-
 
 class _BaseBasis(abc.ABC):
     """Abstract base class for all basis classes."""
-    def __init__(self, transformer=None):
-        """Set the transformer."""
-        self.transformer = transformer
-
-    # Transformer -------------------------------------------------------------
-    @property
-    def transformer(self):
-        """Transformer for pre-processing states before dimension reduction."""
-        return self.__transformer
-
-    @transformer.setter
-    def transformer(self, tf):
-        """Set the transformer, ensuring it has the necessary attributes."""
-        if tf is not None:
-            _check_is_transformer(tf)
-        self.__transformer = tf
 
     # Fitting -----------------------------------------------------------------
     @abc.abstractmethod

--- a/src/opinf/pre/basis/_linear.py
+++ b/src/opinf/pre/basis/_linear.py
@@ -13,7 +13,6 @@ import matplotlib.pyplot as plt
 from ...errors import LoadfileFormatError
 from ...utils import hdf5_savehandle, hdf5_loadhandle
 from .._multivar import _MultivarMixin
-from .. import transform
 from ._base import _BaseBasis
 
 
@@ -22,11 +21,6 @@ class LinearBasis(_BaseBasis):
 
         q = Vr @ q_ := sum([Vr[:, j]*q_[j] for j in range(Vr.shape[1])])
         (full_state = basis * reduced_state).
-
-    Parameters
-    ----------
-    transformer : Transformer or None
-        Transformer for pre-processing states before dimensionality reduction.
 
     Attributes
     ----------
@@ -39,10 +33,9 @@ class LinearBasis(_BaseBasis):
     entries : (n, r) ndarray
         Entries of the basis matrix Vr.
     """
-    def __init__(self, transformer=None):
-        """Initialize an empty basis and set the transformer."""
+    def __init__(self):
+        """Initialize an empty basis."""
         self.__entries = None
-        _BaseBasis.__init__(self, transformer)
 
     # Properties --------------------------------------------------------------
     @property
@@ -70,12 +63,12 @@ class LinearBasis(_BaseBasis):
         return self.entries[key]
 
     def fit(self, basis):
-        """Store the basis entries (without any filtering by the transformer).
+        """Store the basis entries.
 
         Parameters
         ----------
         basis : (n, r) ndarray
-            Basis entries. These entries are NOT filtered by the transformer.
+            Basis entries.
 
         Returns
         -------
@@ -91,8 +84,6 @@ class LinearBasis(_BaseBasis):
     def __str__(self):
         """String representation: class and dimensions."""
         out = [self.__class__.__name__]
-        if self.transformer is not None:
-            out[0] = f"{out[0]} with {self.transformer.__class__.__name__}"
         if self.n is None:
             out[0] = f"Empty {out[0]}"
         else:
@@ -121,11 +112,9 @@ class LinearBasis(_BaseBasis):
             Low-dimensional latent coordinate vector, or a collection of k
             such vectors organized as the columns of a matrix.
         """
-        if self.transformer is not None:
-            state = self.transformer.transform(state)
         return self.entries.T @ state
 
-    def decode(self, state_):
+    def decode(self, state_, locs=None):
         """Map low-dimensional latent coordinates to high-dimensional states.
 
         Parameters
@@ -133,6 +122,9 @@ class LinearBasis(_BaseBasis):
         state_ : (r,) or (r, k) ndarray
             Low-dimensional latent coordinate vector, or a collection of k
             such vectors organized as the columns of a matrix.
+        locs : slice or (p,) ndarray of integers or None
+            If given, return the decoded state at only the specified
+            locations (indices).
 
         Returns
         -------
@@ -140,10 +132,7 @@ class LinearBasis(_BaseBasis):
             High-dimensional state vector, or a collection of k such vectors
             organized as the columns of a matrix.
         """
-        state = self.entries @ state_
-        if self.transformer is not None:
-            state = self.transformer.inverse_transform(state)
-        return state
+        return (self.entries if locs is None else self.entries[locs]) @ state_
 
     # Visualizations ----------------------------------------------------------
     def plot1D(self, x, rmax=None, ax=None, **kwargs):
@@ -190,32 +179,20 @@ class LinearBasis(_BaseBasis):
             return False
         if self.shape != other.shape:
             return False
-        if self.transformer != other.transformer:
-            return False
         return np.all(self.entries == other.entries)
 
-    def save(self, savefile, save_transformer=True, overwrite=False):
+    def save(self, savefile, overwrite=False):
         """Save the basis to an HDF5 file.
 
         Parameters
         ----------
         savefile : str
             Path of the file to save the basis in.
-        save_transformer : bool
-            If True, save the transformer as well as the basis entries.
-            If False, only save the basis entries.
         overwrite : bool
             If True, overwrite the file if it already exists. If False
             (default), raise a FileExistsError if the file already exists.
         """
         with hdf5_savehandle(savefile, overwrite) as hf:
-
-            if save_transformer and self.transformer is not None:
-                meta = hf.create_dataset("meta", shape=(0,))
-                TransformerClass = self.transformer.__class__.__name__
-                meta.attrs["TransformerClass"] = TransformerClass
-                self.transformer.save(hf.create_group("transformer"))
-
             if self.entries is not None:
                 hf.create_dataset("entries", data=self.entries)
 
@@ -230,23 +207,15 @@ class LinearBasis(_BaseBasis):
 
         Returns
         -------
-        _BaseTransformer
+        LinearBasis
         """
-        entries, transformer = None, None
+        entries = None
         with hdf5_loadhandle(loadfile) as hf:
-
-            if "transformer" in hf:
-                if "meta" not in hf:
-                    raise LoadfileFormatError("invalid save format "
-                                              "(meta/ not found)")
-                TransformerClassName = hf["meta"].attrs["TransformerClass"]
-                TransformerClass = getattr(transform, TransformerClassName)
-                transformer = TransformerClass.load(hf["transformer"])
 
             if "entries" in hf:
                 entries = hf["entries"][:]
 
-            return cls(transformer).fit(entries)
+            return cls().fit(entries)
 
 
 class LinearBasisMulti(LinearBasis, _MultivarMixin):
@@ -267,10 +236,6 @@ class LinearBasisMulti(LinearBasis, _MultivarMixin):
         num_variables=3 means the first n entries of a snapshot correspond to
         the first variable, and the next n entries correspond to the second
         variable, and the last n entries correspond to the third variable.
-    transformer : Transformer or None
-        Transformer for pre-processing states before dimensionality reduction.
-        See SnapshotTransformerMulti for a transformer that scales state
-        variables individually.
     variable_names : list of num_variables strings, optional
         Names for each of the `num_variables` variables.
         Defaults to "variable 1", "variable 2", ....
@@ -293,14 +258,13 @@ class LinearBasisMulti(LinearBasis, _MultivarMixin):
     """
     _BasisClass = LinearBasis
 
-    def __init__(self, num_variables, transformer=None, variable_names=None):
-        """Initialize an empty basis and set the transformer."""
-        # Store dimensions and transformer.
+    def __init__(self, num_variables, variable_names=None):
+        """Initialize an empty basis for each variable."""
+        # Store dimensions.
         _MultivarMixin.__init__(self, num_variables, variable_names)
-        LinearBasis.__init__(self, transformer)
+        LinearBasis.__init__(self)
 
-        self.bases = [self._BasisClass(transformer=None)
-                      for _ in range(self.num_variables)]
+        self.bases = [self._BasisClass() for _ in range(self.num_variables)]
 
     # Properties -------------------------------------------------------------
     @property
@@ -339,8 +303,6 @@ class LinearBasisMulti(LinearBasis, _MultivarMixin):
     def __str__(self):
         """String representation: centering and scaling directives."""
         out = [f"{self.num_variables}-variable {self._BasisClass.__name__}"]
-        if self.transformer is not None:
-            out[0] = f"{out[0]} with {self.transformer.__class__.__name__}"
         namelength = max(len(name) for name in self.variable_names)
         sep = " " * (namelength + 5)
         for i, (name, st) in enumerate(zip(self.variable_names, self.bases)):
@@ -357,12 +319,12 @@ class LinearBasisMulti(LinearBasis, _MultivarMixin):
 
     # Main routines -----------------------------------------------------------
     def fit(self, bases):
-        """Store the basis entries (without any filtering by the transformer).
+        """Store the basis entries.
 
         Parameters
         ----------
         bases : list of num_entries (n, ri) ndarrays
-            Basis entries. These entries are NOT filtered by the transformer.
+            Basis entries.
 
         Returns
         -------
@@ -374,16 +336,13 @@ class LinearBasisMulti(LinearBasis, _MultivarMixin):
         return self
 
     # Persistence -------------------------------------------------------------
-    def save(self, savefile, save_transformer=True, overwrite=False):
+    def save(self, savefile, overwrite=False):
         """Save the basis to an HDF5 file.
 
         Parameters
         ----------
         savefile : str
             Path of the file to save the basis in.
-        save_transformer : bool
-            If True, save the transformer as well as the basis entries.
-            If False, only save the basis entries.
         overwrite : bool
             If True, overwrite the file if it already exists. If False
             (default), raise a FileExistsError if the file already exists.
@@ -394,11 +353,6 @@ class LinearBasisMulti(LinearBasis, _MultivarMixin):
             meta = hf.create_dataset("meta", shape=(0,))
             meta.attrs["num_variables"] = self.num_variables
             meta.attrs["variable_names"] = self.variable_names
-
-            if save_transformer and self.transformer is not None:
-                TransformerClass = self.transformer.__class__.__name__
-                meta.attrs["TransformerClass"] = TransformerClass
-                self.transformer.save(hf.create_group("transformer"))
 
             for i in range(self.num_variables):
                 self.bases[i].save(hf.create_group(f"variable{i+1:d}"))
@@ -416,7 +370,6 @@ class LinearBasisMulti(LinearBasis, _MultivarMixin):
         -------
         PODBasis object
         """
-        transformer = None
         with hdf5_loadhandle(loadfile) as hf:
             # Load metadata.
             if "meta" not in hf:
@@ -424,12 +377,6 @@ class LinearBasisMulti(LinearBasis, _MultivarMixin):
                                           "(meta/ not found)")
             num_variables = hf["meta"].attrs["num_variables"]
             variable_names = hf["meta"].attrs["variable_names"].tolist()
-
-            # Load transformer if present.
-            if "transformer" in hf:
-                TransformerClassName = hf["meta"].attrs["TransformerClass"]
-                TransformerClass = getattr(transform, TransformerClassName)
-                transformer = TransformerClass.load(hf["transformer"])
 
             # Load individual bases.
             bases = []
@@ -441,8 +388,7 @@ class LinearBasisMulti(LinearBasis, _MultivarMixin):
                 bases.append(cls._BasisClass.load(hf[group]))
 
             # Initialize and return the basis object.
-            basis = cls(num_variables,
-                        transformer=transformer, variable_names=variable_names)
+            basis = cls(num_variables, variable_names=variable_names)
             basis.bases = bases
             basis._set_entries()
             return basis

--- a/src/opinf/pre/basis/_linear.py
+++ b/src/opinf/pre/basis/_linear.py
@@ -96,8 +96,8 @@ class LinearBasis(_BaseBasis):
         uniqueID = f"<{self.__class__.__name__} object at {hex(id(self))}>"
         return f"{uniqueID}\n{str(self)}"
 
-    # Encoder / decoder -------------------------------------------------------
-    def encode(self, state):
+    # Dimension reduction -----------------------------------------------------
+    def compress(self, state):
         """Map high-dimensional states to low-dimensional latent coordinates.
 
         Parameters
@@ -114,7 +114,7 @@ class LinearBasis(_BaseBasis):
         """
         return self.entries.T @ state
 
-    def decode(self, state_, locs=None):
+    def decompress(self, state_, locs=None):
         """Map low-dimensional latent coordinates to high-dimensional states.
 
         Parameters
@@ -123,7 +123,7 @@ class LinearBasis(_BaseBasis):
             Low-dimensional latent coordinate vector, or a collection of k
             such vectors organized as the columns of a matrix.
         locs : slice or (p,) ndarray of integers or None
-            If given, return the decoded state at only the specified
+            If given, return the decompressed state at only the specified
             locations (indices).
 
         Returns

--- a/src/opinf/pre/basis/_linear.py
+++ b/src/opinf/pre/basis/_linear.py
@@ -17,10 +17,17 @@ from ._base import _BaseBasis
 
 
 class LinearBasis(_BaseBasis):
-    """Linear basis for representing the low-dimensional approximation
+    r"""Linear basis for representing the low-dimensional state approximation
 
-        q = Vr @ q_ := sum([Vr[:, j]*q_[j] for j in range(Vr.shape[1])])
-        (full_state = basis * reduced_state).
+    .. math::
+        \mathbf{q}
+        \approx \mathbf{V}_{r}\widehat{\mathbf{q}}
+        = \sum_{i=1}^{r}\hat{q}_{i}\mathbf{v}_{i},
+    where :math:`\mathbf{q}\in\mathbb{R}^{n}`,
+    :math:`\mathbf{V}_{r}
+    = [\mathbf{v}_{1}, \ldots, \mathbf{v}_{r}]\in \mathbb{R}^{n\times r}`, and
+    :math:`\widehat{\mathbf{q}}
+    = [\hat{q}_{1},\ldots,\hat{q}_{r}]\in\mathbb{R}^{r}`.
 
     Attributes
     ----------
@@ -31,7 +38,7 @@ class LinearBasis(_BaseBasis):
     shape : tulpe
         Dimensions (n, r).
     entries : (n, r) ndarray
-        Entries of the basis matrix Vr.
+        Entries of the basis matrix :math:`\mathbf{V}_{r}`.
     """
     def __init__(self):
         """Initialize an empty basis."""

--- a/src/opinf/pre/basis/_linear.py
+++ b/src/opinf/pre/basis/_linear.py
@@ -123,14 +123,15 @@ class LinearBasis(_BaseBasis):
             Low-dimensional latent coordinate vector, or a collection of k
             such vectors organized as the columns of a matrix.
         locs : slice or (p,) ndarray of integers or None
-            If given, return the decompressed state at only the specified
+            If given, return the reconstructed state at only the specified
             locations (indices).
 
         Returns
         -------
         state : (n,) or (n, k) ndarray
             High-dimensional state vector, or a collection of k such vectors
-            organized as the columns of a matrix.
+            organized as the columns of a matrix. If `locs` is given, only
+            the specified coordinates are returned.
         """
         return (self.entries if locs is None else self.entries[locs]) @ state_
 

--- a/src/opinf/pre/basis/_pod.py
+++ b/src/opinf/pre/basis/_pod.py
@@ -60,7 +60,7 @@ class PODBasis(LinearBasis):
         self.__entries = None
         self.__svdvals = None
         self.__dual = None
-        self.__spatialweights = None
+        # self.__spatialweights = None
         self.economize = bool(economize)
         LinearBasis.__init__(self)
 
@@ -168,53 +168,53 @@ class PODBasis(LinearBasis):
         """Leading *right* singular vectors."""
         return None if self.__dual is None else self.__dual[:, :self.r]
 
-    @property
-    def spatialweights(self):
-        """Symmetric positive definite weighting matrix for the inner product.
-        """
-        return self.__spatialweights
+    # @property
+    # def spatialweights(self):
+    #     """Symmetric positive definite weighting matrix for the inner
+    #     product. """
+    #     return self.__spatialweights
 
-    @spatialweights.setter
-    def spatialweights(self, weights):
-        """Set the spatial weights, checking dimension."""
-        if weights is not None and self.n is not None:
-            if weights.shape[0] != self.n:
-                raise ValueError(f"{weights.shape} spatialweights "
-                                 f"not aligned with dimension n = {self.n}")
-        self.__spatialweights = weights
+    # @spatialweights.setter
+    # def spatialweights(self, weights):
+    #     """Set the spatial weights, checking dimension."""
+    #     if weights is not None and self.n is not None:
+    #         if weights.shape[0] != self.n:
+    #             raise ValueError(f"{weights.shape} spatialweights "
+    #                              f"not aligned with dimension n = {self.n}")
+    #     self.__spatialweights = weights
 
-    def _spatial_weighting(self, state, weights):
-        """Weight a state or a collection of states (spatially)."""
-        if weights is not None:
-            if weights.ndim == 1:
-                if state.ndim == 2:
-                    weights = weights.reshape(-1, 1)
-                return weights * state
-            return weights @ state
-        return state
+    # def _spatial_weighting(self, state, weights):
+    #     """Weight a state or a collection of states (spatially)."""
+    #     if weights is not None:
+    #         if weights.ndim == 1:
+    #             if state.ndim == 2:
+    #                 weights = weights.reshape(-1, 1)
+    #             return weights * state
+    #         return weights @ state
+    #     return state
 
     # Dimension reduction -----------------------------------------------------
-    def compress(self, state):
-        """Map high-dimensional states to low-dimensional latent coordinates.
+    # def compress(self, state):
+    #     """Map high-dimensional states to low-dimensional latent coordinates.
 
-        Parameters
-        ----------
-        state : (n,) or (n, k) ndarray
-            High-dimensional state vector, or a collection of k such vectors
-            organized as the columns of a matrix.
+    #     Parameters
+    #     ----------
+    #     state : (n,) or (n, k) ndarray
+    #         High-dimensional state vector, or a collection of k such vectors
+    #         organized as the columns of a matrix.
 
-        Returns
-        -------
-        state_ : (r,) or (r, k) ndarray
-            Low-dimensional latent coordinate vector, or a collection of k
-            such vectors organized as the columns of a matrix.
-        """
-        # if self.spatialweights.ndim == 1 and
-        # # state.ndim == 2 and state.shape[1] < self.r:
-        #     return self._spatial_weighting(self.entries,
-        #                                 self.spatialweights).T @ state
-        return self.entries.T @ self._spatial_weighting(state,
-                                                        self.spatialweights)
+    #     Returns
+    #     -------
+    #     state_ : (r,) or (r, k) ndarray
+    #         Low-dimensional latent coordinate vector, or a collection of k
+    #         such vectors organized as the columns of a matrix.
+    #     """
+    #     # if self.spatialweights.ndim == 1 and
+    #     # # state.ndim == 2 and state.shape[1] < self.r:
+    #     #     return self._spatial_weighting(self.entries,
+    #     #                                 self.spatialweights).T @ state
+    #     return self.entries.T @ self._spatial_weighting(state,
+    #                                                     self.spatialweights)
 
     # Fitting -----------------------------------------------------------------
     @staticmethod
@@ -230,8 +230,8 @@ class PODBasis(LinearBasis):
         self.__svdvals = np.sort(svals)[::-1] if svals is not None else None
         self.__dual = Wt.T if Wt is not None else None
 
-    def _fit(self, driver, states, r, cumulative_energy, residual_energy,
-             spatialweights, temporalweights, **options):
+    def _fit(self, driver, states,
+             r, cumulative_energy, residual_energy, **options):
         """Compute the POD basis of rank r corresponding to the states using
         `driver()` to compute the SVD.
 
@@ -262,43 +262,43 @@ class PODBasis(LinearBasis):
         This method computes the full singular value decomposition of `states`.
         The method fit_randomized() uses a randomized SVD.
         """
+        #  spatialweights, temporalweights, **options):
         if np.ndim(states) == 3:
             # Concatenate list of states.
             states = np.hstack(states)
         self._validate_rank(states, r)
 
-        # Weight the states.
-        if spatialweights is not None:
-            if spatialweights.ndim == 1:
-                root_weights = np.sqrt(spatialweights)
-                inv_root_weights = 1 / root_weights
-            elif spatialweights.ndim == 2:
-                root_weights = la.sqrtm(spatialweights)
-                inv_root_weights = la.inv(root_weights)
-            else:
-                raise ValueError("1D spatial weights only")
-            states = self._spatial_weighting(states, root_weights)
+        # # Weight the states.
+        # if spatialweights is not None:
+        #     if spatialweights.ndim == 1:
+        #         root_weights = np.sqrt(spatialweights)
+        #         inv_root_weights = 1 / root_weights
+        #     elif spatialweights.ndim == 2:
+        #         root_weights = la.sqrtm(spatialweights)
+        #         inv_root_weights = la.inv(root_weights)
+        #     else:
+        #         raise ValueError("1D spatial weights only")
+        #     states = self._spatial_weighting(states, root_weights)
 
         # Compute the SVD.
         V, svdvals, Wt = driver(states, **options)
 
         # Unweight the basis vectors.
-        if spatialweights is not None:
-            if spatialweights.ndim == 1:
-                V *= np.reshape(1 / root_weights, (-1, 1))
-            elif spatialweights.ndim == 2:
-                V = inv_root_weights @ V
+        # if spatialweights is not None:
+        #     if spatialweights.ndim == 1:
+        #         V *= np.reshape(1 / root_weights, (-1, 1))
+        #     elif spatialweights.ndim == 2:
+        #         V = inv_root_weights @ V
 
         # Store the results.
         self._store_svd(V, svdvals, Wt)
         self.set_dimension(r, cumulative_energy, residual_energy)
-        self.spatialweights = spatialweights
+        # self.spatialweights = spatialweights
 
         return self
 
     def fit(self, states,
-            r=None, cumulative_energy=None, residual_energy=None,
-            spatialweights=None, temporalweights=None, **options):
+            r=None, cumulative_energy=None, residual_energy=None, **options):
         """Compute the POD basis of rank r corresponding to the states
         via the compact/thin singular value decomposition (scipy.linalg.svd()).
 
@@ -327,14 +327,14 @@ class PODBasis(LinearBasis):
         This method computes the full singular value decomposition of `states`.
         The method fit_randomized() uses a randomized SVD.
         """
+        # spatialweights=None, temporalweights=None, **options):
         options["full_matrices"] = False
 
         return self._fit(la.svd,
                          states, r, cumulative_energy, residual_energy,
-                         spatialweights, temporalweights, **options)
+                         **options)
 
-    def fit_randomized(self, states, r,
-                       spatialweights=None, temporalweights=None, **options):
+    def fit_randomized(self, states, r, **options):
         """Compute the POD basis of rank r corresponding to the states
         via the randomized singular value decomposition
         (sklearn.utils.extmath.randomized_svd()).
@@ -355,13 +355,15 @@ class PODBasis(LinearBasis):
         value decomposition, which can be useful for very large n.
         The method fit() computes the full singular value decomposition.
         """
+        # spatialweights=None, temporalweights=None, **options):
         if "random_state" not in options:
             options["random_state"] = None
         options["n_components"] = r
 
         return self._fit(sklmath.randomized_svd,
                          states, r, None, None,
-                         spatialweights, temporalweights, **options)
+                         # spatialweights, temporalweights,
+                         **options)
 
     # Visualization -----------------------------------------------------------
     def _check_svdvals_exist(self):
@@ -415,7 +417,7 @@ class PODBasis(LinearBasis):
 
         Parameters
         ----------
-        threshold : 0 ≤ float ≤ 1 or None
+        threshold : 0 ≤ float ≤ 1 or None
             Cutoff value to mark on the plot.
         ax : plt.Axes or None
             Matplotlib Axes to plot on. If None, a new figure is created.
@@ -453,7 +455,7 @@ class PODBasis(LinearBasis):
 
         Parameters
         ----------
-        threshold : 0 ≤ float ≤ 1 or None
+        threshold : 0 ≤ float ≤ 1 or None
             Cutoff value to mark on the plot.
         ax : plt.Axes or None
             Matplotlib Axes to plot on. If None, a new figure is created.

--- a/src/opinf/pre/basis/_pod.py
+++ b/src/opinf/pre/basis/_pod.py
@@ -193,8 +193,8 @@ class PODBasis(LinearBasis):
             return weights @ state
         return state
 
-    # Encoding ----------------------------------------------------------------
-    def encode(self, state):
+    # Dimension reduction -----------------------------------------------------
+    def compress(self, state):
         """Map high-dimensional states to low-dimensional latent coordinates.
 
         Parameters

--- a/src/opinf/pre/transform/_base.py
+++ b/src/opinf/pre/transform/_base.py
@@ -61,7 +61,7 @@ class _BaseTransformer(abc.ABC):
         raise NotImplementedError                           # pragma: no cover
 
     @abc.abstractmethod
-    def inverse_transform(self, states_transformed, inplace=False):
+    def inverse_transform(self, states_transformed, inplace=False, locs=None):
         """Apply the inverse of the learned transformation.
 
         Parameters
@@ -71,11 +71,15 @@ class _BaseTransformer(abc.ABC):
         inplace : bool
             If True, overwrite the input data during inverse transformation.
             If False, create a copy of the data to untransform.
+        locs : slice or (p,) ndarray of integers or None
+            If given, return the untransformed variable at only the specified
+            locations (indices). In this case, `inplace` is ignored.
 
         Returns
         -------
         states: (n, k) ndarray
-            Matrix of k untransformed snapshots of dimension n.
+            Matrix of k untransformed snapshots of dimension n, or the p
+            entries of such at the indices specified by `loc`.
         """
         raise NotImplementedError                           # pragma: no cover
 
@@ -88,10 +92,3 @@ class _BaseTransformer(abc.ABC):
     def load(cls, *args, **kwargs):
         """Load a transformer from an HDF5 file."""
         raise NotImplementedError("use pickle/joblib")
-
-
-def _check_is_transformer(obj):
-    """Raise a RuntimeError if `obj` cannot be used as a transformer."""
-    for mtd in _BaseTransformer.__abstractmethods__:
-        if not hasattr(obj, mtd):
-            raise TypeError(f"transformer missing required method {mtd}()")

--- a/tests/core/nonparametric/test_public.py
+++ b/tests/core/nonparametric/test_public.py
@@ -179,10 +179,10 @@ class TestDiscreteOpInfROM:
         for form in MODEL_FORMS:
             if "B" not in form:             # No control inputs.
                 rom = _trainedmodel(self.ModelClass, form, Vr, None)
-                out = rom.predict(q0, niters, decode=True)
+                out = rom.predict(q0, niters, decompress=True)
                 assert isinstance(out, np.ndarray)
                 assert out.shape == (n, niters)
-                out2 = rom.predict(q0, niters, decode=False)
+                out2 = rom.predict(q0, niters, decompress=False)
                 assert isinstance(out2, np.ndarray)
                 assert out2.shape == (r, niters)
                 assert np.allclose(Vr @ out2, out)
@@ -190,21 +190,21 @@ class TestDiscreteOpInfROM:
             else:                           # Has Control inputs.
                 # Predict with 2D inputs.
                 rom = _trainedmodel(self.ModelClass, form, Vr, m)
-                out = rom.predict(q0, niters, U, decode=True)
+                out = rom.predict(q0, niters, U, decompress=True)
                 assert isinstance(out, np.ndarray)
                 assert out.shape == (n, niters)
 
                 # Predict with 1D inputs.
                 rom = _trainedmodel(self.ModelClass, form, Vr, 1)
                 out = rom.predict(q0, niters, np.ones(niters),
-                                  decode=False)
+                                  decompress=False)
                 assert isinstance(out, np.ndarray)
                 assert out.shape == (r, niters)
 
         # Predict with no basis gives result in low-dimensional space.
         rom = _trainedmodel(self.ModelClass, "cA", Vr, None)
         rom.basis = None
-        out = rom.predict(Vr.T @ q0, niters, decode=True)
+        out = rom.predict(Vr.T @ q0, niters, decompress=True)
         assert isinstance(out, np.ndarray)
         assert out.shape == (r, niters)
 
@@ -353,17 +353,17 @@ class TestContinuousOpInfROM:
         for form in MODEL_FORMS:
             if "B" not in form:
                 rom = _trainedmodel(self.ModelClass, form, Vr, None)
-                out = rom.predict(q0, t, decode=True)
+                out = rom.predict(q0, t, decompress=True)
                 assert isinstance(out, np.ndarray)
                 assert out.shape == (n, t.size)
-                out = rom.predict(q0, t, decode=False)
+                out = rom.predict(q0, t, decompress=False)
                 assert isinstance(out, np.ndarray)
                 assert out.shape == (r, t.size)
 
         # Predict with no basis gives result in low-dimensional space.
         rom = _trainedmodel(self.ModelClass, "cA", Vr, None)
         rom.basis = None
-        out = rom.predict(Vr.T @ q0, t, decode=True)
+        out = rom.predict(Vr.T @ q0, t, decompress=True)
         assert isinstance(out, np.ndarray)
         assert out.shape == (r, t.size)
 
@@ -411,22 +411,22 @@ class TestContinuousOpInfROM:
                 # continuous input.
                 for method in ["RK45", "BDF"]:
                     out = rom.predict(q0, t, input_func,
-                                      decode=True, method=method)
+                                      decompress=True, method=method)
                     assert isinstance(out, np.ndarray)
                     assert out.shape == (n, nt)
                 # discrete input.
-                out = rom.predict(q0, t, Upred, decode=False)
+                out = rom.predict(q0, t, Upred, decompress=False)
                 assert isinstance(out, np.ndarray)
                 assert out.shape == (r, nt)
 
                 # Predict with 1D inputs.
                 rom = _trainedmodel(self.ModelClass, form, Vr, 1)
                 # continuous input.
-                out = rom.predict(q0, t, lambda t: 1, decode=True)
+                out = rom.predict(q0, t, lambda t: 1, decompress=True)
                 assert isinstance(out, np.ndarray)
                 assert out.shape == (n, nt)
                 out = rom.predict(q0, t, lambda t: np.array([1]),
-                                  decode=False)
+                                  decompress=False)
                 assert isinstance(out, np.ndarray)
                 assert out.shape == (r, nt)
                 # discrete input.

--- a/tests/core/test_base.py
+++ b/tests/core/test_base.py
@@ -562,63 +562,63 @@ class TestBaseROM:
 
         # TODO: Special case: G(q) = q^3
 
-    def test_encode(self, n=60, k=50, r=10):
-        """Test _BaseROM.encode()."""
+    def test_compress(self, n=60, k=50, r=10):
+        """Test _BaseROM.compress()."""
         Q, Qdot, _ = _get_data(n, k, 2)
         rom = self.Dummy("c")
 
-        # Try to encode without reduced dimension r set.
+        # Try to compress without reduced dimension r set.
         with pytest.raises(AttributeError) as ex:
-            rom.encode(Q, 'things')
+            rom.compress(Q, 'things')
         assert ex.value.args[0] == "reduced dimension not set"
 
-        # Try to encode with r set but with wrong shape.
+        # Try to compress with r set but with wrong shape.
         rom.r = r
         with pytest.raises(AttributeError) as ex:
-            rom.encode(Q, 'arg')
+            rom.compress(Q, 'arg')
         assert ex.value.args[0] == "basis not set"
 
-        # Try to encode with basis set but with wrong shape.
+        # Try to compress with basis set but with wrong shape.
         Vr = np.random.random((n, r))
         rom.basis = Vr
         with pytest.raises(ValueError) as ex:
-            rom.encode(Q[:-1, :], 'state')
+            rom.compress(Q[:-1, :], 'state')
         assert ex.value.args[0] == "state not aligned with basis"
 
         # Correct usage.
         for S, label in [(Q, 'state'), (Qdot, 'ddts')]:
-            S_ = rom.encode(S, label)
+            S_ = rom.compress(S, label)
             assert S_.shape == (r, k)
             assert np.allclose(S_, Vr.T @ S)
-            assert np.allclose(S_, rom.basis.encode(S))
-            S_ = rom.encode(S[:r, :], label)
+            assert np.allclose(S_, rom.basis.compress(S))
+            S_ = rom.compress(S[:r, :], label)
             assert S_.shape == (r, k)
             assert np.all(S_ == S[:r, :])
 
-    def test_decode(self, n=60, k=20, r=8):
-        """Test _BaseROM.decode()."""
+    def test_decompress(self, n=60, k=20, r=8):
+        """Test _BaseROM.decompress()."""
         Q_, Qdot_, _ = _get_data(r, k, 2)
         rom = self.Dummy("c")
 
-        # Try to decode without basis.
+        # Try to decompress without basis.
         rom.r = r
         with pytest.raises(AttributeError) as ex:
-            rom.decode(Q_, 'arg')
+            rom.decompress(Q_, 'arg')
         assert ex.value.args[0] == "basis not set"
 
-        # Try to encode with basis set but with wrong shape.
+        # Try to compress with basis set but with wrong shape.
         Vr = np.random.random((n, r))
         rom.basis = Vr
         with pytest.raises(ValueError) as ex:
-            rom.decode(Q_[:-1, :], 'state')
+            rom.decompress(Q_[:-1, :], 'state')
         assert ex.value.args[0] == "state not aligned with basis"
 
         # Correct usage.
         for S_, label in [(Q_, 'state_'), (Qdot_, 'ddts_')]:
-            S = rom.decode(S_, label)
+            S = rom.decompress(S_, label)
             assert S.shape == (n, k)
             assert np.allclose(S, Vr @ S_)
-            assert np.allclose(S, rom.basis.decode(S_))
+            assert np.allclose(S, rom.basis.decompress(S_))
 
     # def test_project(self, n=63, k=19, r=7):
     #     """Lightly test _BaseROM.project()."""

--- a/tests/pre/basis/test_base.py
+++ b/tests/pre/basis/test_base.py
@@ -1,8 +1,6 @@
 # pre/basis/test_base.py
 """Tests for pre.basis._base."""
 
-import pytest
-
 import opinf
 
 
@@ -19,29 +17,6 @@ class TestBaseBasis:
 
         def decode(self, state_):
             return state_ - 1
-
-    class DummyTransformer:
-        """Dummy object with all required transformer methods."""
-        def fit_transform(self, states):
-            return states
-
-        def transform(self, states):
-            return states
-
-        def inverse_transform(self, states):
-            return states
-
-    def test_init(self):
-        """Test _BaseBasis.__init__() and transformer properties."""
-        self.Dummy()
-
-        with pytest.raises(TypeError) as ex:
-            self.Dummy(10)
-        assert ex.value.args[0].startswith("transformer missing required meth")
-
-        transformer = self.DummyTransformer()
-        basis = self.Dummy(transformer)
-        assert basis.transformer is transformer
 
     def test_project(self):
         """Test _BaseBasis.project() and _BaseBasis.projection_error()."""

--- a/tests/pre/basis/test_base.py
+++ b/tests/pre/basis/test_base.py
@@ -12,10 +12,10 @@ class TestBaseBasis:
         def fit(self):
             pass
 
-        def encode(self, state):
+        def compress(self, state):
             return state + 2
 
-        def decode(self, state_):
+        def decompress(self, state_):
             return state_ - 1
 
     def test_project(self):

--- a/tests/pre/basis/test_linear.py
+++ b/tests/pre/basis/test_linear.py
@@ -54,22 +54,22 @@ class TestLinearBasis:
             "\nFull-order dimension    n = 9" \
             "\nReduced-order dimension r = 5"
 
-    # Encoder / decoder -------------------------------------------------------
-    def test_encode(self, n=9, r=4):
-        """Test encode()."""
+    # Dimension reduction  ----------------------------------------------------
+    def test_compress(self, n=9, r=4):
+        """Test compress()."""
         Vr = np.random.random((n, r))
         basis = self.LinearBasis().fit(Vr)
         q = np.random.random(n)
         q_ = Vr.T @ q
-        assert np.allclose(basis.encode(q), q_)
+        assert np.allclose(basis.compress(q), q_)
 
-    def test_decode(self, n=9, r=4):
-        """Test encode()."""
+    def test_decompress(self, n=9, r=4):
+        """Test decompress()."""
         Vr = np.random.random((n, r))
         basis = self.LinearBasis().fit(Vr)
         q_ = np.random.random(r)
         q = Vr @ q_
-        assert np.allclose(basis.decode(q_), q)
+        assert np.allclose(basis.decompress(q_), q)
 
     # Visualization -----------------------------------------------------------
     def test_plot1D(self, n=20, r=4):

--- a/tests/pre/basis/test_linear.py
+++ b/tests/pre/basis/test_linear.py
@@ -71,6 +71,10 @@ class TestLinearBasis:
         q = Vr @ q_
         assert np.allclose(basis.decompress(q_), q)
 
+        # Get only a few coordinates.
+        locs = np.array([0, 2], dtype=int)
+        assert np.allclose(basis.decompress(q_, locs=locs), q[locs])
+
     # Visualization -----------------------------------------------------------
     def test_plot1D(self, n=20, r=4):
         """Lightly test plot1D()."""

--- a/tests/pre/basis/test_pod.py
+++ b/tests/pre/basis/test_pod.py
@@ -207,6 +207,7 @@ class TestPODBasis:
         # Repeat with list of state trajectories.
         states = [np.random.standard_normal((n, n)) for _ in range(4)]
         basis = self.PODBasis()
+        options.pop("random_state")
         basis.fit_randomized(states, r, **options)
         assert basis.n == n
 

--- a/tests/pre/basis/test_pod.py
+++ b/tests/pre/basis/test_pod.py
@@ -105,8 +105,8 @@ class TestPODBasis:
         assert basis.shape == (n, 1)
         assert basis.dual.shape == (n, 1)
         assert basis.svdvals.shape == (r,)
-        assert basis.encode(np.random.random(n,)).shape == (1,)
-        assert basis.encode(np.random.random((n, n))).shape == (1, n)
+        assert basis.compress(np.random.random(n,)).shape == (1,)
+        assert basis.compress(np.random.random((n, n))).shape == (1, n)
 
     def test_set_dimension(self, n=20):
         """Test set_dimension()."""

--- a/tests/pre/transform/test_base.py
+++ b/tests/pre/transform/test_base.py
@@ -41,22 +41,3 @@ class TestBaseTransformer:
         with pytest.raises(NotImplementedError) as ex:
             self.Dummy.load("test")
         assert ex.value.args[0] == "use pickle/joblib"
-
-
-def test_check_is_transformer():
-    """Test pre.transform._base._check_is_transformer()."""
-
-    class Dummy:
-        def transform(self):
-            pass
-
-        def fit_transform(self):
-            pass
-
-    with pytest.raises(TypeError) as ex:
-        opinf.pre.transform._base._check_is_transformer(Dummy())
-    assert ex.value.args[0] == \
-        "transformer missing required method inverse_transform()"
-
-    dummy = TestBaseTransformer.Dummy()
-    opinf.pre.transform._base._check_is_transformer(dummy)


### PR DESCRIPTION
- Fixed a bug where the `SnapshotTransformer` class would not persist correctly when saving to an external file and loading later.
- **API Change**: Basis and ROM classes now have `compress()`/`decompress()` methods instead of `encode()`/`decode()` methods. A few versions ago these were `project()`/`reconstruct()`, I promise this is the last name change.
- **minor API Change**: Basis classes used to accept a transformer object at instantiation so that `basis.compress()` would do the transformation _and_ the dimension reduction. This lead to some confusing bugs in practice (and unnecessarily complicated code), so removed this feature.