### PR TITLE
Bugfix: InterpolatedROM save()

### DIFF
--- a/src/opinf/__init__.py
+++ b/src/opinf/__init__.py
@@ -7,7 +7,7 @@ GitHub:
     https://github.com/Willcox-Research-Group/rom-operator-inference-Python3
 """
 
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 
 from .roms import *
 from .operators import *

--- a/src/opinf/roms/interpolate/_base.py
+++ b/src/opinf/roms/interpolate/_base.py
@@ -377,9 +377,12 @@ class _InterpolatedOpInfROM(_BaseParametricROM):
 
             # Store reduced operators.
             for key, op in zip(self.modelform, self):
-                if "parameters" not in hf:
-                    hf.create_dataset("parameters", data=op.parameters)
-                hf.create_dataset(f"operators/{key}_", data=op.matrices)
+                if operators.is_parametric_operator(op):
+                    if "parameters" not in hf:
+                        hf.create_dataset("parameters", data=op.parameters)
+                    hf.create_dataset(f"operators/{key}_", data=op.matrices)
+                else:
+                    hf.create_dataset(f"operators/{key}_", data=op.entries)
 
     @classmethod
     def load(cls, loadfile, InterpolatorClass):
@@ -409,8 +412,6 @@ class _InterpolatedOpInfROM(_BaseParametricROM):
                 raise ValueError("invalid save format (meta/ not found)")
             if "operators" not in hf:
                 raise ValueError("invalid save format (operators/ not found)")
-            if "parameters" not in hf:
-                raise ValueError("invalid save format (parameters/ not found)")
 
             # Load metadata.
             modelform = hf["meta"].attrs["modelform"]
@@ -422,7 +423,8 @@ class _InterpolatedOpInfROM(_BaseParametricROM):
                 basis = getattr(_basis, BasisClassName).load(hf["basis"])
 
             # Load operators.
-            parameters = hf["parameters"][:]
+            if "parameters" in hf:
+                parameters = hf["parameters"][:]
             ops = {}
             for key in modelform:
                 attr = f"{key}_"

--- a/tests/basis/test_linear.py
+++ b/tests/basis/test_linear.py
@@ -193,9 +193,8 @@ class TestLinearBasisMulti:
         """Test LinearBasisMulti properties r, rs, and entries."""
         basis = self.LinearBasisMulti(nvars)
 
-        with pytest.raises(AttributeError) as ex:
+        with pytest.raises(AttributeError):
             basis.r = 3
-        assert ex.value.args[0].startswith("can't set attribute")
 
         # To test r, rs, and entries, we need to set the basis entries.
         rs = [i + 2 for i in range(nvars)]

--- a/tests/basis/test_pod.py
+++ b/tests/basis/test_pod.py
@@ -343,9 +343,8 @@ class TestPODBasisMulti:
         """Test properties r, rs, economize, and entries."""
         basis = self.PODBasisMulti(nvars, False)
 
-        with pytest.raises(AttributeError) as ex:
+        with pytest.raises(AttributeError):
             basis.r = 3
-        assert ex.value.args[0].startswith("can't set attribute")
 
         with pytest.raises(AttributeError) as ex:
             basis.rs = [3] * basis.num_variables

--- a/tests/operators/test_affine.py
+++ b/tests/operators/test_affine.py
@@ -79,9 +79,8 @@ class TestAffineOperator:
 
         # Ensure these attributes are all properties.
         for attr in ["coefficient_functions", "matrices", "shape"]:
-            with pytest.raises(AttributeError) as ex:
+            with pytest.raises(AttributeError):
                 setattr(op, attr, 10)
-            assert ex.value.args[0].startswith("can't set attribute")
 
     def test_validate_coefficient_functions(self):
         """Test _AffineOperator._validate_coefficient_functions()."""

--- a/tests/operators/test_base.py
+++ b/tests/operators/test_base.py
@@ -110,9 +110,8 @@ class TestBaseParametricOperator:
         assert dummy.OperatorClass is _module._BaseNonparametricOperator
 
         # Try changing the OperatorClass.
-        with pytest.raises(AttributeError) as ex:
+        with pytest.raises(AttributeError):
             dummy.OperatorClass = int
-        assert ex.value.args[0].startswith("can't set attribute")
 
         # Try instantiating a class with an invalid OperatorClass.
         with pytest.raises(RuntimeError) as ex:

--- a/tests/operators/test_interpolate.py
+++ b/tests/operators/test_interpolate.py
@@ -98,9 +98,8 @@ class TestInterpolatedOperator:
 
         # Ensure these attributes are all properties.
         for attr in ["parameters", "matrices", "shape", "interpolator"]:
-            with pytest.raises(AttributeError) as ex:
+            with pytest.raises(AttributeError):
                 setattr(op, attr, 10)
-            assert ex.value.args[0].startswith("can't set attribute")
 
     def test_call(self):
         """Test _InterpolatedOperator.__call__()."""

--- a/tests/pre/test_shift_scale.py
+++ b/tests/pre/test_shift_scale.py
@@ -581,9 +581,8 @@ class TestSnapshotTransformerMulti:
         stm = opinf.pre.SnapshotTransformerMulti(2)
         for attr in "num_variables", "center", "scaling":
             assert hasattr(stm, attr)
-            with pytest.raises(AttributeError) as ex:
+            with pytest.raises(AttributeError):
                 setattr(stm, attr, 0)
-            assert ex.value.args[0].startswith("can't set attribute")
 
         # Variable names.
         stm = opinf.pre.SnapshotTransformerMulti(3, variable_names=None)

--- a/tests/roms/interpolate/test_base.py
+++ b/tests/roms/interpolate/test_base.py
@@ -460,11 +460,6 @@ class TestInterpolatedOpInfROM:
             hf.create_dataset("operators/A_", data=ops["A"])
             hf.create_dataset("operators/B_", data=ops["B"])
 
-        with pytest.raises(ValueError) as ex:
-            self.Dummy.load(target, None)
-        assert ex.value.args[0] == \
-            "invalid save format (parameters/ not found)"
-
         # Store the parameters.
         with h5py.File(target, 'a') as hf:
             hf.create_dataset("parameters", data=params)

--- a/tests/roms/interpolate/test_public.py
+++ b/tests/roms/interpolate/test_public.py
@@ -1,7 +1,7 @@
 # roms/interpolate/test_public.py
 """Tests for roms.interpolate._public."""
 
-# import pytest
+import os
 import numpy as np
 import scipy.interpolate
 import scipy.linalg as la
@@ -251,3 +251,27 @@ class TestInterpolatedContinuousOpInfROM:
                                for tt in t]).T
             predicted = rom.predict(p, q0, t)
             assert np.allclose(predicted, actual)
+
+    def test_issue46(self, target="_interpcontinuoussavetest.h5"):
+        # Clean up after old tests.
+        if os.path.isfile(target):  # pragma: no cover
+            os.remove(target)
+
+        # Reproduce the issue.
+        N = 10
+        K = 5
+        n_snaps = 8
+        Phi = np.random.normal(size=(N, K))
+        states = np.random.normal(size=(N, n_snaps))
+        states_dot = np.random.normal(size=(N, n_snaps))
+        params = np.array([1])
+        rom = opinf.InterpolatedContinuousOpInfROM(
+            "A", InterpolatorClass="auto"
+        )
+        rom.fit(Phi, parameters=params, states=[states], ddts=[states_dot])
+
+        # Problem should be here.
+        rom.save(target, overwrite=True)
+
+        # Clean up.
+        os.remove(target)


### PR DESCRIPTION
Resolves #46. Also shaved down a few tests of whether or not an attribute was a property that resulted in failed tests depending on the python version.

This bugfix moves the package to version `0.4.6`.