### PR TITLE
2024: Drop 3.8 support, test on 3.9-3.12

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.10
       - name: Install package
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -6,7 +6,7 @@ on:
   #   types: [published]
   workflow_dispatch:
 
-# Installs dependencies, builds the documentation, and push it to `gh-pages`
+# Installs dependencies, builds the documentation, and push it to `gh-pages`.
 jobs:
   deploy-docs:
     runs-on: ubuntu-latest
@@ -15,7 +15,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: 3.11
       - name: Install package
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -22,10 +22,9 @@ jobs:
           - windows-latest
           - macos-latest
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
-          # - "3.11"  # Needs special treatment to install HDF5
+          - "3.11"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -25,6 +25,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_src.yml
+++ b/.github/workflows/test_src.yml
@@ -22,10 +22,9 @@ jobs:
           - windows-latest
           - macos-latest
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
-          # - "3.11"  # Needs special treatment to install HDF5
+          - "3.11"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_src.yml
+++ b/.github/workflows/test_src.yml
@@ -39,6 +39,8 @@ jobs:
           python -m pip install ".[tests]"
           python -m pip list --format=freeze
       - name: Lint code
+        # TEMP: do not lint in 3.12 until black and flake8 reconcile.
+        if: ${{ matrix.python-version < 3.12 }}
         run: |
           python -m flake8 src
           python -m flake8 tests

--- a/.github/workflows/test_src.yml
+++ b/.github/workflows/test_src.yml
@@ -25,6 +25,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 maintainers = [{ name = "Shane A. McQuarrie", email = "shanemcq@utexas.edu" }]
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { file = "LICENSE" }
 keywords = [
     "operator inference",


### PR DESCRIPTION
Happy new year, Python 3.8 [dies this October](https://devguide.python.org/versions/). This PR would drop support for Python 3.8, making 0.5.1 the final release where we run tests on 3.8. CI tests are also updated to now test Python 3.12 (in addition to 3.9 and 3.10).