### PR TITLE
Set default regularizer to float value

### DIFF
--- a/src/opinf/lstsq/_tikhonov.py
+++ b/src/opinf/lstsq/_tikhonov.py
@@ -78,7 +78,7 @@ class L2Solver(_BaseTikhonovSolver):
 
     _LSTSQ_LABEL = r"min_{X} ||AX - B||_F^2 + ||λX||_F^2"
 
-    def __init__(self, regularizer=0):
+    def __init__(self, regularizer=0.0):
         """Store the regularizer and initialize attributes.
 
         Parameters


### PR DESCRIPTION
Simply sets the default regularizer to 0.0 instead of 0. My linter complained as shown in the screenshot attached; re-setting the default removed this message.

<img width="1438" alt="Screenshot 2024-05-10 at 10 07 23" src="https://github.com/Willcox-Research-Group/rom-operator-inference-Python3/assets/72927083/e704b14f-05a6-4c0e-b8e7-deddcfe0ee10">
