### PR TITLE
Intersphinx + Fix Attribute/Property Docs

### DIFF
--- a/.github/workflows/test_src.yml
+++ b/.github/workflows/test_src.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  tests:
     strategy:
       max-parallel: 4
       fail-fast: false

--- a/.github/workflows/test_style.yml
+++ b/.github/workflows/test_style.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  style:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,9 @@ all: test docs
 
 
 # Deployment (ADMINISTRATORS ONLY) --------------------------------------------
-deploy_package: test
+deploy_package:
 	git checkout main
+	$(TOX)
 	$(PIP) --upgrade build
 	$(PIP) --upgrade twine
 	$(REMOVE) dist/
@@ -68,7 +69,8 @@ deploy_package: test
 	$(PYTHON) -m twine upload dist/*
 
 
-deploy_docs: docs  # clean_docs
-	$(PYTHON) -m pip install --upgrade ghp-import
+deploy_docs: # clean_docs
 	git checkout main
+	$(TOX) -e literature,docs
+	$(PYTHON) -m pip install --upgrade ghp-import
 	ghp-import --remote upstream --no-jekyll --push --force --no-history docs/_build/html

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -55,6 +55,9 @@ sphinx:
       scipy:
         - "https://docs.scipy.org/doc/scipy/"
         - null
+      sklearn:
+        - "https://scikit-learn.org/stable/"
+        - null
     mathjax3_config:
       tex:
         macros:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -53,6 +53,9 @@ sphinx:
     bibtex_reference_style: label
     # bibtex_default_style: plain       # Citations as numbers.
     intersphinx_mapping:
+      numpy:
+        - "https://numpy.org/doc/stable/"
+        - null
       scipy:
         - "https://docs.scipy.org/doc/scipy/"
         - null

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -14,12 +14,13 @@ repository:
 
 # GitHub buttons and other web options.
 html:
+  extra_css: ["_static/properties.css"]
+  favicon: images/favicon.svg
   home_page_in_navbar: false
   use_edit_page_button: false
   use_issues_button: true
   use_multitoc_numbering: false
   use_repository_button: true
-  favicon: images/favicon.svg
 
 # Notebooks execution configuration for build.
 # See https://jupyterbook.org/content/execute.html

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -51,11 +51,10 @@ sphinx:
     autosummary_generate: true          # Turn on sphinx.ext.autosummary.
     bibtex_reference_style: label
     # bibtex_default_style: plain       # Citations as numbers.
-    # intersphinx_mapping: {
-    #   "python": ("https://docs.python.org/3", None),
-    #   "numpy": ("https://numpy.org/devdocs", None),
-    #   "matplotlib": ("https://matplotlib.org/stable", None),
-    # }
+    intersphinx_mapping:
+      scipy:
+        - "https://docs.scipy.org/doc/scipy/"
+        - null
     mathjax3_config:
       tex:
         macros:
@@ -125,6 +124,7 @@ sphinx:
     - sphinx_design
     - sphinx.ext.autodoc
     - sphinx.ext.autosummary
+    - sphinx.ext.intersphinx
     - sphinx.ext.napoleon
     - sphinx.ext.viewcode
     - sphinxcontrib.mermaid

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -53,8 +53,14 @@ sphinx:
     bibtex_reference_style: label
     # bibtex_default_style: plain       # Citations as numbers.
     intersphinx_mapping:
+      matplotlib:
+        - "https://matplotlib.org/stable/"
+        - null
       numpy:
         - "https://numpy.org/doc/stable/"
+        - null
+      python:
+        - "https://docs.python.org/3/"
         - null
       scipy:
         - "https://docs.scipy.org/doc/scipy/"

--- a/docs/_static/properties.css
+++ b/docs/_static/properties.css
@@ -1,0 +1,12 @@
+/* Color and style of property names */
+dl.py.attribute dt.sig.sig-object.py .sig-name.descname {
+    color: inherit;
+    font-size: inherit;
+    font-weight: bold;
+}
+
+/* Indent and reduce space between properties */
+dl.py.attribute {
+    margin-bottom: .5em !important;
+    padding-left: 2.5em;
+}

--- a/docs/source/contributing/how_to_contribute.md
+++ b/docs/source/contributing/how_to_contribute.md
@@ -87,7 +87,7 @@ It will help prevent automated tests from failing when a pull request is made.
 The source repository has three special branches:
 
 - `main` is the most up-to-date version of the code. Tags on the `main` branch correspond to [public PyPi releases](https://pypi.org/project/opinf/).
-- `gh-pages` contains only the current build files for this documentation. _This branch is updated by maintainers only._
+- `gh-pages` contains only the current build files for this documentation. *This branch is updated by maintainers only.*
 - `data` contains only data files used in documentation demos.
 
 To contribute, get synced with the `main` branch, then start a new branch for making active changes.

--- a/docs/source/opinf/installation.md
+++ b/docs/source/opinf/installation.md
@@ -8,20 +8,20 @@ To avoid conflicts with other installed packages, we recommend installing `opinf
 
 ```shell
 # Make a fresh conda environment and install Python 3.11.
-conda create -n opinf3.11 python=3.11
+conda create -n opinf python=3.12
 ```
 
 Be sure to [activate](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#activating-an-environment) the environment before using `pip` or other installation tools.
 
 ```shell
 # Activate the conda environment (updates the PATH).
-$ conda activate opinf3.11
+$ conda activate opinf
 
 # Verify python is now linked to the conda environment.
-$ which python3
-/path/to/your/conda/envs/opinf3.11/bin/python3
+(opinf) $ which python3
+/path/to/your/conda/envs/opinf/bin/python3
 $ python3 --version
-Python 3.11.8
+Python 3.12.3
 ```
 
 :::
@@ -30,8 +30,8 @@ Python 3.11.8
 To check if the package is already installed in the current Python environment, run the following in the command line.
 
 ```shell
-$ python3 -m pip freeze | grep opinf
-9:opinf==0.5.1
+(opinf) $ python3 -m pip freeze | grep opinf
+9:opinf==0.5.5
 ```
 
 No output means the package was not found.
@@ -39,12 +39,12 @@ No output means the package was not found.
 
 ## Latest Release from PyPi (Recommended)
 
-We recommend installing the package from [the Python Package Index](https://pypi.org/) with [`pip`](https://pypi.org/project/pip/).
+We recommend installing the package from [the Python Package Index](https://pypi.org/project/opinf/) with [`pip`](https://pypi.org/project/pip/).
 This installs the [latest official release](https://github.com/Willcox-Research-Group/rom-operator-inference-Python3/releases).
 
 ```shell
-conda activate opinf3.11
-python3 -m pip install opinf
+$ conda activate opinf
+(opinf) $ python3 -m pip install opinf
 ```
 
 ## Latest Commit to Main Branch
@@ -53,8 +53,13 @@ The following command installs the latest version from the `main` branch, which 
 This requires [`git`](https://git-scm.com/).
 
 ```shell
-conda activate opinf3.11
-python3 -m pip install git+https://github.com/Willcox-Research-Group/rom-operator-inference-Python3.git
+$ conda activate opinf
+
+# Install with git + SSH credentials (recommended).
+(opinf) $ python3 -m pip install git+ssh://git@github.com/Willcox-Research-Group/rom-operator-inference-Python3.git
+
+# Install with git + HTTPS.
+(opinf) $ python3 -m pip install git+https://github.com/Willcox-Research-Group/rom-operator-inference-Python3.git
 ```
 
 ## Source Code
@@ -64,7 +69,7 @@ This also requires [`git`](https://git-scm.com/) and is the first step for contr
 See the [Developer Guide](../contributing/how_to_contribute.md) if you are interested in contributing.
 
 ```shell
-git clone https://github.com/Willcox-Research-Group/rom-operator-inference-Python3.git
-conda activate opinf3.11
-python3 -m pip install rom-operator-inference-Python3
+$ git clone git@github.com:Willcox-Research-Group/rom-operator-inference-Python3.git OpInf
+$ conda activate opinf
+(opinf) $ python3 -m pip install OpInf
 ```

--- a/docs/templates/autosummary/class.rst
+++ b/docs/templates/autosummary/class.rst
@@ -10,13 +10,16 @@
    {% block properties %}
    {% if attributes %}
 
-   **Properties**
+   .. raw:: html
 
-   .. autosummary::
+      <div style="background-color: #f4f4f4; padding: 0px; margin-bottom: 0px; margin-top: 2em">
+         <strong>Properties:</strong>
+      </div>
+
    {% for item in all_attributes %}
-      {%- if not item.startswith('_') %}
-      ~{{ name }}.{{ item }}
-      {%- endif -%}
+   {%- if not item.startswith('_') %}
+   .. autoattribute:: {{ name }}.{{ item }}
+   {%- endif -%}
    {%- endfor %}
    {% endif %}
    {% endblock %}
@@ -24,7 +27,11 @@
    {% block methods %}
    {% if methods %}
 
-   **Methods**
+   .. raw:: html
+
+      <div style="background-color: #f4f4f4; padding: 0px; margin-bottom: 0px; margin-top: 2em">
+         <strong>Methods:</strong>
+      </div>
 
    .. autosummary::
       :toctree:

--- a/src/opinf/basis/_linear.py
+++ b/src/opinf/basis/_linear.py
@@ -25,7 +25,7 @@ class LinearBasis(BasisTemplate):
 
     This class approximates high-dimensional states :math:`\q\in\RR^n` as a
     linear combination of :math:`r` basis vectors
-    :math:`\v_1,\ldots,\v_r\in\R^n`. The basis matrix
+    :math:`\v_1,\ldots,\v_r\in\RR^n`. The basis matrix
     :math:`\Vr = [~\v_1~~\cdots~~\v_r~]\in \RR^{n \times r}` and an (optional)
     weighting matrix :math:`\W\in\RR^{n \times n}` define the approximation.
 

--- a/src/opinf/basis/_pod.py
+++ b/src/opinf/basis/_pod.py
@@ -104,8 +104,8 @@ class PODBasis(LinearBasis):
 
         **Options:**
 
-        * ``"dense"`` (default): Use ``scipy.linalg.svd()`` to compute the SVD.
-          May be inefficient for very large state matrices.
+        * ``"dense"`` (default): Use :func:`scipy.linalg.svd()` to
+          compute the SVD. May be inefficient for very large state matrices.
         * ``"randomized"``: Compute an approximate SVD with a randomized
           approach via ``sklearn.utils.extmath.randomized_svd()``.
           May be more efficient but less accurate for very large state
@@ -114,7 +114,7 @@ class PODBasis(LinearBasis):
           only ``max_vectors`` singular *values* are computed as well, meaning
           the cumulative and residual energies cannot be computed exactly.
         * callable: If this argument is a callable function, use it for the
-          SVD computation. The signature must match ``scipy.linalg.svd()``,
+          SVD computation. The signature must match :func:`scipy.linalg.svd()`,
           i.e., ``U, s, Vh = svdsolver(states, **svdsolver_options)``
     weights : (n, n) ndarray or (n,) ndarray None
         Weight matrix :math:`\W` or its diagonals.

--- a/src/opinf/basis/_pod.py
+++ b/src/opinf/basis/_pod.py
@@ -107,7 +107,7 @@ class PODBasis(LinearBasis):
         * ``"dense"`` (default): Use :func:`scipy.linalg.svd()` to
           compute the SVD. May be inefficient for very large state matrices.
         * ``"randomized"``: Compute an approximate SVD with a randomized
-          approach via ``sklearn.utils.extmath.randomized_svd()``.
+          approach via :func:`sklearn.utils.extmath.randomized_svd()`.
           May be more efficient but less accurate for very large state
           matrices. **NOTE**: it is highly recommended to set ``max_vectors``
           to limit the number of computed singular vectors. In this case,

--- a/src/opinf/ddt/_finite_difference.py
+++ b/src/opinf/ddt/_finite_difference.py
@@ -920,8 +920,8 @@ class NonuniformFiniteDifferencer(DerivativeEstimatorTemplate):
     """Time derivative estimation with finite differences for state snapshots
     that are **not** spaced uniformly in time.
 
-    This class essentially wraps ``np.gradient()``, which uses second-order
-    finite differences.
+    This class essentially wraps :func:`numpy.gradient()`, which uses
+    second-order finite differences.
 
     Parameters
     ----------

--- a/src/opinf/lstsq/_base.py
+++ b/src/opinf/lstsq/_base.py
@@ -380,16 +380,16 @@ class PlainSolver(SolverTemplate):
     .. math::
         \argmin_{\Ohat} \|\D\Ohat\trp - \Z\trp\|_F^2.
 
-    The solution is calculated using ``scipy.linalg.lstsq()``.
+    The solution is calculated using :func:`scipy.linalg.lstsq()`.
 
     Parameters
     ----------
     cond : float or None
         Cutoff for 'small' singular values of the data matrix.
-        See ``scipy.linalg.lstsq()``.
+        See :func:`scipy.linalg.lstsq()`.
     lapack_driver : str or None
         Which LAPACK driver is used to solve the least-squares problem.
-        See ``scipy.linalg.lstsq()``.
+        See :func:`scipy.linalg.lstsq()`.
     """
 
     def __init__(self, cond=None, lapack_driver=None):
@@ -401,7 +401,7 @@ class PlainSolver(SolverTemplate):
 
     @property
     def options(self):
-        """Keyword arguments for ``scipy.linalg.lstsq()``."""
+        """Keyword arguments for :func:`scipy.linalg.lstsq()`."""
         return self.__options
 
     def __str__(self):
@@ -433,7 +433,7 @@ class PlainSolver(SolverTemplate):
 
     def predict(self):
         r"""Solve the Operator Inference regression via
-        ``scipy.linalg.lstsq()``.
+        :func:`scipy.linalg.lstsq()`.
 
         Returns
         -------

--- a/src/opinf/lstsq/_tikhonov.py
+++ b/src/opinf/lstsq/_tikhonov.py
@@ -199,7 +199,7 @@ class L2Solver(_BaseRegularizedSolver):
     regularizer : float
         Scalar :math:`L_2` regularization constant.
     lapack_driver : str
-        LAPACK routine for computing the SVD. See ``scipy.linalg.svd()``.
+        LAPACK routine for computing the SVD. See :func:`scipy.linalg.svd()`.
     """
 
     def __init__(self, regularizer, lapack_driver: str = "gesdd"):
@@ -229,7 +229,7 @@ class L2Solver(_BaseRegularizedSolver):
 
     @property
     def options(self):
-        """Keyword arguments for ``scipy.linalg.svd()``."""
+        """Keyword arguments for :func:`scipy.linalg.svd()`."""
         return self.__options
 
     def __str__(self):
@@ -402,7 +402,7 @@ class L2DecoupledSolver(L2Solver):
         Scalar :math:`L_2` regularization constants, one for each row
         of the operator matrix.
     lapack_driver : str
-        LAPACK routine for computing the SVD. See ``scipy.linalg.svd()``.
+        LAPACK routine for computing the SVD. See :func:`scipy.linalg.svd()`.
     """
 
     # Properties --------------------------------------------------------------
@@ -533,18 +533,18 @@ class TikhonovSolver(_BaseRegularizedSolver):
         **Options**:
 
         * ``"lstsq"``: solve the stacked least-squares problem via
-          ``scipy.linalg.lstsq()``; by default, this computes and uses the
+          :func:`scipy.linalg.lstsq()`; by default, this computes and uses the
           singular value decomposition of the stacked data matrix
           :math:`[~D\trp~~\bfGamma\trp~]\trp`.
         * ``"normal"``: directly solve the normal equations
           :math:`(\D\trp\D + \bfGamma\trp\bfGamma) \Ohat\trp = \D\trp\Z\trp`
-          via ``scipy.linalg.solve()``.
+          via :func:`scipy.linalg.solve()`.
     cond : float or None
         Cutoff for 'small' singular values of the data matrix,
-        see ``scipy.linalg.lstsq()``. Ignored if ``method = "normal"``.
+        see :func:`scipy.linalg.lstsq()`. Ignored if ``method = "normal"``.
     lapack_driver : str or None
         Which LAPACK driver is used to solve the least-squares problem,
-        see ``scipy.linalg.lstsq()``. Ignored if ``method = "normal"``.
+        see :func:`scipy.linalg.lstsq()`. Ignored if ``method = "normal"``.
     """
 
     def __init__(
@@ -565,7 +565,7 @@ class TikhonovSolver(_BaseRegularizedSolver):
     # Properties --------------------------------------------------------------
     @property
     def options(self):
-        """Keyword arguments for ``scipy.linalg.lstsq()``."""
+        """Keyword arguments for :func:`scipy.linalg.lstsq()`."""
         return self.__options
 
     def __str__(self):
@@ -800,18 +800,18 @@ class TikhonovDecoupledSolver(TikhonovSolver):
         **Options**:
 
         * ``"lstsq"``: solve the stacked least-squares problem via
-          ``scipy.linalg.lstsq()``; by default, this computes and uses the
+          :func:`scipy.linalg.lstsq()`; by default, this computes and uses the
           singular value decomposition of the stacked data matrix
           :math:`[~D\trp~~\bfGamma\trp~]\trp`.
         * ``"normal"``: directly solve the normal equations
           :math:`(\D\trp\D + \bfGamma\trp\bfGamma) \Ohat\trp = \D\trp\Z\trp`
-          via ``scipy.linalg.solve()``.
+          via :func:`scipy.linalg.solve()`.
     cond : float or None
         Cutoff for 'small' singular values of the data matrix,
-        see ``scipy.linalg.lstsq()``. Ignored if ``method = "normal"``.
+        see :func:`scipy.linalg.lstsq()`. Ignored if ``method = "normal"``.
     lapack_driver : str or None
         Which LAPACK driver is used to solve the least-squares problem,
-        see ``scipy.linalg.lstsq()``. Ignored if ``method = "normal"``.
+        see :func:`scipy.linalg.lstsq()`. Ignored if ``method = "normal"``.
     """
 
     # Properties --------------------------------------------------------------

--- a/src/opinf/lstsq/_tikhonov.py
+++ b/src/opinf/lstsq/_tikhonov.py
@@ -202,7 +202,7 @@ class L2Solver(_BaseRegularizedSolver):
         LAPACK routine for computing the SVD. See ``scipy.linalg.svd()``.
     """
 
-    def __init__(self, regularizer, lapack_driver="gesdd"):
+    def __init__(self, regularizer, lapack_driver: str = "gesdd"):
         """Store the regularizer and initialize attributes."""
         _BaseRegularizedSolver.__init__(self)
         self.regularizer = regularizer

--- a/src/opinf/lstsq/_total.py
+++ b/src/opinf/lstsq/_total.py
@@ -46,7 +46,7 @@ class TotalLeastSquaresSolver(SolverTemplate):
     Parameters
     ----------
     lapack_driver : str
-        LAPACK routine for computing the SVD. See ``scipy.linalg.svd()``.
+        LAPACK routine for computing the SVD. See :func:`scipy.linalg.svd()`.
     """
 
     def __init__(self, lapack_driver: str = "gesdd"):
@@ -58,7 +58,7 @@ class TotalLeastSquaresSolver(SolverTemplate):
     # Properties --------------------------------------------------------------
     @property
     def options(self):
-        """Keyword arguments for ``scipy.linalg.svd()``."""
+        """Keyword arguments for :func:`scipy.linalg.svd()`."""
         return self.__options
 
     def __str__(self):

--- a/src/opinf/models/mono/_nonparametric.py
+++ b/src/opinf/models/mono/_nonparametric.py
@@ -492,10 +492,10 @@ class SteadyModel(_NonparametricModel):  # pragma: no cover
     solver : :mod:`opinf.lstsq` object or float > 0 or None
         Solver for the least-squares regression. Defaults:
 
-        * ``None``: :class:`opinf.lstsq.PlainSolver`, SVD-based solve
-            without regularization.
-        * float > 0: :class:`opinf.lstsq.L2Solver`, SVD-based solve with
-            scalar Tikhonov regularization.
+        * ``None``: :class:`opinf.lstsq.PlainSolver`.
+          SVD-based solve without regularization.
+        * float > 0: :class:`opinf.lstsq.L2Solver`.
+          SVD-based solve with scalar Tikhonov regularization.
     """
 
     _LHS_ARGNAME = "forcing"
@@ -611,10 +611,10 @@ class DiscreteModel(_NonparametricModel):
     solver : :mod:`opinf.lstsq` object or float > 0 or None
         Solver for the least-squares regression. Defaults:
 
-        * ``None``: :class:`opinf.lstsq.PlainSolver`, SVD-based solve
-            without regularization.
-        * float > 0: :class:`opinf.lstsq.L2Solver`, SVD-based solve with
-            scalar Tikhonov regularization.
+        * ``None``: :class:`opinf.lstsq.PlainSolver`.
+          SVD-based solve without regularization.
+        * float > 0: :class:`opinf.lstsq.L2Solver`.
+          SVD-based solve with scalar Tikhonov regularization.
     """
 
     _LHS_ARGNAME = "nextstates"
@@ -846,10 +846,10 @@ class ContinuousModel(_NonparametricModel):
     solver : :mod:`opinf.lstsq` object or float > 0 or None
         Solver for the least-squares regression. Defaults:
 
-        * ``None``: :class:`opinf.lstsq.PlainSolver`, SVD-based solve
-            without regularization.
-        * float > 0: :class:`opinf.lstsq.L2Solver`, SVD-based solve with
-            scalar Tikhonov regularization.
+        * ``None``: :class:`opinf.lstsq.PlainSolver`.
+          SVD-based solve without regularization.
+        * float > 0: :class:`opinf.lstsq.L2Solver`.
+          SVD-based solve with scalar Tikhonov regularization.
     """
 
     _LHS_ARGNAME = "ddts"
@@ -961,7 +961,7 @@ class ContinuousModel(_NonparametricModel):
 
     def predict(self, state0, t, input_func=None, **options):
         """Solve the system of ordinary differential equations.
-        This method wraps ``scipy.integrate.solve_ivp()``.
+        This method wraps :func:`scipy.integrate.solve_ivp()`.
 
         Parameters
         ----------
@@ -974,8 +974,7 @@ class ContinuousModel(_NonparametricModel):
             times ``t``. If given as an array, cubic spline interpolation on
             the known data points is used as needed.
         options
-            Arguments for ``scipy.integrate.solve_ivp()``,
-            See https://docs.scipy.org/doc/scipy/reference/integrate.html.
+            Arguments for :func:`scipy.integrate.solve_ivp()`.
             Common options:
 
             * **method : str** ODE solver for the model.

--- a/src/opinf/models/mono/_parametric.py
+++ b/src/opinf/models/mono/_parametric.py
@@ -895,7 +895,7 @@ class _ParametricContinuousMixin:
 
     def predict(self, parameter, state0, t, input_func=None, **options):
         r"""Solve the system of ordinary differential equations.
-        This method wraps ``scipy.integrate.solve_ivp()``.
+        This method wraps :func:`scipy.integrate.solve_ivp()`.
 
         Parameters
         ----------
@@ -910,8 +910,7 @@ class _ParametricContinuousMixin:
             times ``t``. If given as an array, cubic spline interpolation on
             the known data points is used as needed.
         options
-            Arguments for ``scipy.integrate.solve_ivp()``,
-            See https://docs.scipy.org/doc/scipy/reference/integrate.html.
+            Arguments for :func:`scipy.integrate.solve_ivp()`.
             Common options:
 
             * **method : str** ODE solver for the model.
@@ -1017,10 +1016,10 @@ class _InterpolatedModel(_ParametricModel):
            >>> interpolator = InterpolatorClass(data_points, data_values)
            >>> interpolator_evaluation = interpolator(new_data_point)
 
-        This can be, e.g., a class from ``scipy.interpolate``.
-        If ``None`` (default), use ``scipy.interpolate.CubicSpline``
+        This can be, e.g., a class from :mod:`scipy.interpolate`.
+        If ``None`` (default), use :class:`scipy.interpolate.CubicSpline`
         for one-dimensional parameters and
-        ``scipy.interpolate.LinearNDInterpolator`` otherwise.
+        :class:`scipy.interpolate.LinearNDInterpolator` otherwise.
     """
 
     @property
@@ -1051,10 +1050,10 @@ class _InterpolatedModel(_ParametricModel):
                >>> interpolator = InterpolatorClass(data_points, data_values)
                >>> interpolator_evaluation = interpolator(new_data_point)
 
-            This can be, e.g., a class from ``scipy.interpolate``.
-            If ``None`` (default), use ``scipy.interpolate.CubicSpline``
+            This can be, e.g., a class from :mod:`scipy.interpolate`.
+            If ``None`` (default), use :class:`scipy.interpolate.CubicSpline`
             for one-dimensional parameters and
-            ``scipy.interpolate.LinearNDInterpolator`` otherwise.
+            :class:`scipy.interpolate.LinearNDInterpolator` otherwise.
         """
         # Check for consistency in the models.
         opclasses = [type(op) for op in models[0].operators]
@@ -1104,10 +1103,10 @@ class _InterpolatedModel(_ParametricModel):
                 >>> interpolator = InterpolatorClass(data_points, data_values)
                 >>> interpolator_evaluation = interpolator(new_data_point)
 
-            This can be, e.g., a class from ``scipy.interpolate``.
-            If ``None`` (default), use ``scipy.interpolate.CubicSpline``
+            This can be, e.g., a class from :mod:`scipy.interpolate`.
+            If ``None`` (default), use :class:`scipy.interpolate.CubicSpline`
             for one-dimensional parameters and
-            ``scipy.interpolate.LinearNDInterpolator`` otherwise.
+            :class:`scipy.interpolate.LinearNDInterpolator` otherwise.
         """
         if InterpolatorClass is not None:
             for op in self.operators:
@@ -1271,7 +1270,7 @@ class _InterpolatedModel(_ParametricModel):
                >>> interpolator_evaluation = interpolator(new_data_point)
 
             Not required if the saved operator utilizes a class from
-            ``scipy.interpolate``.
+            :mod:`scipy.interpolate`.
 
         Returns
         -------
@@ -1363,10 +1362,10 @@ class InterpolatedDiscreteModel(_ParametricDiscreteMixin, _InterpolatedModel):
             >>> interpolator = InterpolatorClass(data_points, data_values)
             >>> interpolator_evaluation = interpolator(new_data_point)
 
-        This can be, e.g., a class from ``scipy.interpolate``.
-        If ``None`` (default), use ``scipy.interpolate.CubicSpline``
+        This can be, e.g., a class from :mod:`scipy.interpolate`.
+        If ``None`` (default), use :class:`scipy.interpolate.CubicSpline`
         for one-dimensional parameters and
-        ``scipy.interpolate.LinearNDInterpolator`` otherwise.
+        :class:`scipy.interpolate.LinearNDInterpolator` otherwise.
     """
 
     pass
@@ -1399,10 +1398,10 @@ class InterpolatedContinuousModel(
             >>> interpolator = InterpolatorClass(data_points, data_values)
             >>> interpolator_evaluation = interpolator(new_data_point)
 
-        This can be, e.g., a class from ``scipy.interpolate``.
-        If ``None`` (default), use ``scipy.interpolate.CubicSpline``
+        This can be, e.g., a class from :mod:`scipy.interpolate`.
+        If ``None`` (default), use :class:`scipy.interpolate.CubicSpline`
         for one-dimensional parameters and
-        ``scipy.interpolate.LinearNDInterpolator`` otherwise.
+        :class:`scipy.interpolate.LinearNDInterpolator` otherwise.
     """
 
     pass

--- a/src/opinf/operators/_interpolate.py
+++ b/src/opinf/operators/_interpolate.py
@@ -74,10 +74,10 @@ class _InterpolatedOperator(_ParametricOperator):
             >>> interpolator = InterpolatorClass(data_points, data_values)
             >>> interpolator_evaluation = interpolator(new_data_point)
 
-        This can be, e.g., a class from ``scipy.interpolate``.
-        If ``None`` (default), use ``scipy.interpolate.CubicSpline``
+        This can be, e.g., a class from :mod:`scipy.interpolate`.
+        If ``None`` (default), use :class:`scipy.interpolate.CubicSpline`
         for one-dimensional parameters and
-        ``scipy.interpolate.LinearNDInterpolator`` otherwise.
+        :class:`scipy.interpolate.LinearNDInterpolator` otherwise.
         If not provided in the constructor, use :meth:`set_interpolator` later.
     fromblock : bool
         If ``True``, interpret ``entries`` as a horizontal concatenation
@@ -278,7 +278,7 @@ class _InterpolatedOperator(_ParametricOperator):
                >>> interpolator = InterpolatorClass(data_points, data_values)
                >>> interpolator_evaluation = interpolator(new_data_point)
 
-            This can be, e.g., a class from ``scipy.interpolate``.
+            This can be, e.g., a class from :mod:`scipy.interpolate`.
         """
         if self.entries is not None:
             # Default interpolator classes.
@@ -531,7 +531,7 @@ class _InterpolatedOperator(_ParametricOperator):
                >>> interpolator_evaluation = interpolator(new_data_point)
 
             Not required if the saved operator utilizes a class from
-            ``scipy.interpolate``.
+            :mod:`scipy.interpolate`.
 
         Returns
         -------
@@ -614,10 +614,10 @@ class InterpolatedConstantOperator(_InterpolatedOperator):
             >>> interpolator = InterpolatorClass(data_points, data_values)
             >>> interpolator_evaluation = interpolator(new_data_point)
 
-        This can be, e.g., a class from ``scipy.interpolate``.
-        If ``None`` (default), use ``scipy.interpolate.CubicSpline``
+        This can be, e.g., a class from :mod:`scipy.interpolate`.
+        If ``None`` (default), use :class:`scipy.interpolate.CubicSpline`
         for one-dimensional parameters and
-        ``scipy.interpolate.LinearNDInterpolator`` otherwise.
+        :class:`scipy.interpolate.LinearNDInterpolator` otherwise.
         If not provided in the constructor, use :meth:`set_interpolator` later.
     fromblock : bool
         If ``True``, interpret ``entries`` as a horizontal concatenation
@@ -662,10 +662,10 @@ class InterpolatedLinearOperator(_InterpolatedOperator):
             >>> interpolator = InterpolatorClass(data_points, data_values)
             >>> interpolator_evaluation = interpolator(new_data_point)
 
-        This can be, e.g., a class from ``scipy.interpolate``.
-        If ``None`` (default), use ``scipy.interpolate.CubicSpline``
+        This can be, e.g., a class from :mod:`scipy.interpolate`.
+        If ``None`` (default), use :class:`scipy.interpolate.CubicSpline`
         for one-dimensional parameters and
-        ``scipy.interpolate.LinearNDInterpolator`` otherwise.
+        :class:`scipy.interpolate.LinearNDInterpolator` otherwise.
         If not provided in the constructor, use :meth:`set_interpolator` later.
     fromblock : bool
         If ``True``, interpret ``entries`` as a horizontal concatenation
@@ -710,10 +710,10 @@ class InterpolatedQuadraticOperator(_InterpolatedOperator):
             >>> interpolator = InterpolatorClass(data_points, data_values)
             >>> interpolator_evaluation = interpolator(new_data_point)
 
-        This can be, e.g., a class from ``scipy.interpolate``.
-        If ``None`` (default), use ``scipy.interpolate.CubicSpline``
+        This can be, e.g., a class from :mod:`scipy.interpolate`.
+        If ``None`` (default), use :class:`scipy.interpolate.CubicSpline`
         for one-dimensional parameters and
-        ``scipy.interpolate.LinearNDInterpolator`` otherwise.
+        :class:`scipy.interpolate.LinearNDInterpolator` otherwise.
         If not provided in the constructor, use :meth:`set_interpolator` later.
     fromblock : bool
         If ``True``, interpret ``entries`` as a horizontal concatenation
@@ -759,10 +759,10 @@ class InterpolatedCubicOperator(_InterpolatedOperator):
             >>> interpolator = InterpolatorClass(data_points, data_values)
             >>> interpolator_evaluation = interpolator(new_data_point)
 
-        This can be, e.g., a class from ``scipy.interpolate``.
-        If ``None`` (default), use ``scipy.interpolate.CubicSpline``
+        This can be, e.g., a class from :mod:`scipy.interpolate`.
+        If ``None`` (default), use :class:`scipy.interpolate.CubicSpline`
         for one-dimensional parameters and
-        ``scipy.interpolate.LinearNDInterpolator`` otherwise.
+        :class:`scipy.interpolate.LinearNDInterpolator` otherwise.
         If not provided in the constructor, use :meth:`set_interpolator` later.
     fromblock : bool
         If ``True``, interpret ``entries`` as a horizontal concatenation
@@ -808,10 +808,10 @@ class InterpolatedInputOperator(_InterpolatedOperator, _InputMixin):
             >>> interpolator = InterpolatorClass(data_points, data_values)
             >>> interpolator_evaluation = interpolator(new_data_point)
 
-        This can be, e.g., a class from ``scipy.interpolate``.
-        If ``None`` (default), use ``scipy.interpolate.CubicSpline``
+        This can be, e.g., a class from :mod:`scipy.interpolate`.
+        If ``None`` (default), use :class:`scipy.interpolate.CubicSpline`
         for one-dimensional parameters and
-        ``scipy.interpolate.LinearNDInterpolator`` otherwise.
+        :class:`scipy.interpolate.LinearNDInterpolator` otherwise.
         If not provided in the constructor, use :meth:`set_interpolator` later.
     fromblock : bool
         If ``True``, interpret ``entries`` as a horizontal concatenation
@@ -861,10 +861,10 @@ class InterpolatedStateInputOperator(_InterpolatedOperator, _InputMixin):
             >>> interpolator = InterpolatorClass(data_points, data_values)
             >>> interpolator_evaluation = interpolator(new_data_point)
 
-        This can be, e.g., a class from ``scipy.interpolate``.
-        If ``None`` (default), use ``scipy.interpolate.CubicSpline``
+        This can be, e.g., a class from :mod:`scipy.interpolate`.
+        If ``None`` (default), use :class:`scipy.interpolate.CubicSpline`
         for one-dimensional parameters and
-        ``scipy.interpolate.LinearNDInterpolator`` otherwise.
+        :class:`scipy.interpolate.LinearNDInterpolator` otherwise.
         If not provided in the constructor, use :meth:`set_interpolator` later.
     fromblock : bool
         If ``True``, interpret ``entries`` as a horizontal concatenation

--- a/src/opinf/pre/_shiftscale.py
+++ b/src/opinf/pre/_shiftscale.py
@@ -77,7 +77,7 @@ def scale(states: np.ndarray, scale_to: tuple, scale_from: tuple = None):
        q' = \frac{q - a}{b - a}(b' - a') + a',
 
     where :math:`q` is the original variable and :math:`q'` is the transformed
-    variable. This follows ``sklearn.preprocessing.MinMaxScaler``.
+    variable. This follows :class:`sklearn.preprocessing.MinMaxScaler`.
 
     Parameters
     ----------

--- a/src/opinf/utils/_hdf5.py
+++ b/src/opinf/utils/_hdf5.py
@@ -18,7 +18,7 @@ class _hdf5_filehandle:
 
     Parameters
     ----------
-    filename : str of h5py File/Group handle
+    filename : str or h5py File/Group handle
         * str : Name of the file to interact with.
         * h5py File/Group handle : handle to part of an already open HDF5 file.
     mode : str
@@ -77,7 +77,7 @@ class hdf5_savehandle(_hdf5_filehandle):
 
     Parameters
     ----------
-    savefile : str of h5py File/Group handle
+    savefile : str or h5py File/Group handle
         * str : Name of the file to save to.
         * h5py File/Group handle : handle to part of an already open HDF5 file
           to save data to.
@@ -100,7 +100,7 @@ class hdf5_loadhandle(_hdf5_filehandle):
 
     Parameters
     ----------
-    loadfile : str of h5py File/Group handle
+    loadfile : str or h5py File/Group handle
         * str : Name of the file to read from.
         * h5py File/Group handle : handle to part of an already open HDF5 file
           to read data from.

--- a/tests/lstsq/test_base.py
+++ b/tests/lstsq/test_base.py
@@ -372,6 +372,8 @@ class TestPlainSolver:
         assert np.all(solver2.data_matrix == D)
         assert np.all(solver2.lhs_matrix == Z)
 
+        os.remove(outfile)
+
     def test_copy(self, k=18, d=10, r=4):
         """Test copy()."""
         solver = self.Solver(lapack_driver="gelsy")


### PR DESCRIPTION
A few improvements to the documentation.
- Added intersphinx for python, numpy, scipy, matplotlib, and scikit-learn. Now the documentation has direct links to, e.g., `scipy.linalg.lstsq()` where relevant.
- Changed `docs/templates/class.rst` so that the properties are not listed with autodoc, but with autoattribute. This prevents jupyter book (really sphinx) from complaining that there's a link to a nonexistant page for every single class property. The documentation should now compile without any warnings.

No changes to the source code.