### PR TITLE
TruncatedSVDSolver

### DIFF
--- a/docs/source/api/lstsq.ipynb
+++ b/docs/source/api/lstsq.ipynb
@@ -26,6 +26,7 @@
     "   L2DecoupledSolver\n",
     "   TikhonovSolver\n",
     "   TikhonovDecoupledSolver\n",
+    "   TruncatedSVDSolver\n",
     "   TotalLeastSquaresSolver\n",
     "```"
    ]
@@ -37,11 +38,8 @@
     ":::{admonition} Overview\n",
     ":class: note\n",
     "\n",
-    "- Solver classes defined in `opinf.lstsq` are used to solve an Operator Inference regression.\n",
-    "- [`fit()`](SolverTemplate.fit) receives data matrices defining the regression.\n",
-    "- [`predict()`](SolverTemplate.predict) solves the regression and returns the operator matrix.\n",
-    "- Solver objects are passed to the constructor of {mod}`opinf.models` classes.\n",
-    "- Models handle the construction of $\\D$ and $\\Z$ from snapshot data, pass these matrices to the solver's `fit()` method, call the solver's `predict()` method to compute $\\Ohat$, and interpret $\\Ohat$ in the context of the model structure.\n",
+    "- `opinf.lstsq` classes are solve Operator Inference regression problems.\n",
+    "- `opinf.models` classes handle the construction of the regression matrices from snapshot data, pass these matrices to the solver's [`fit()`](SolverTemplate.fit) method, call the solver's [`solve()`](SolverTemplate.solve) method, and interpret the solution in the context of the model structure.\n",
     ":::"
    ]
   },
@@ -72,7 +70,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Least-squares Operator Inference Problems"
+    "## Operator Inference Regression Problems"
    ]
   },
   {
@@ -289,7 +287,7 @@
    "outputs": [],
    "source": [
     "# Solve the least-squares problem for the operator matrix.\n",
-    "Ohat = solver.predict()\n",
+    "Ohat = solver.solve()\n",
     "print(f\"{Ohat.shape=}\")"
    ]
   },
@@ -348,12 +346,12 @@
     "\n",
     "The following classes solve Tikhonov-regularized least-squares Operator Inference regressions for different choices of the regularization term $\\mathcal{R}(\\Ohat)$.\n",
     "\n",
-    "| Solver class                     | Description                                      | Regularization $\\mathcal{R}(\\Ohat)$ |\n",
-    "| :------------------------------- | :----------------------------------------------- | :------------: |\n",
-    "| {class}`L2Solver`                | One scalar regularizer for all $\\ohat_i$         | $\\lambda^{2}||\\Ohat\\trp||_F^2$ |\n",
-    "| {class}`L2DecoupledSolver`       | Different scalar regularizers for each $\\ohat_i$ | $\\sum_{i=1}^{r}\\lambda_i^2||\\ohat_i||_2^2$ |\n",
-    "| {class}`TikhonovSolver`          | One matrix regularizer for all $\\ohat_i$         | $||\\bfGamma\\Ohat\\trp||_F^2$ |\n",
-    "| {class}`TikhonovDecoupledSolver` | Different matrix regularizers for each $\\ohat_i$ | $\\sum_{i=1}^{r}||\\bfGamma_i\\ohat_i||_2^2$ |"
+    "| Solver class                     | Description                                      | Regularization $\\mathcal{R}(\\Ohat)$            |\n",
+    "| :------------------------------- | :----------------------------------------------- | :--------------------------------------------: |\n",
+    "| {class}`L2Solver`                | One scalar regularizer for all $\\ohat_i$         | $\\lambda^{2}\\|\\|\\Ohat\\trp\\|\\|_F^2$             |\n",
+    "| {class}`L2DecoupledSolver`       | Different scalar regularizers for each $\\ohat_i$ | $\\sum_{i=1}^{r}\\lambda_i^2\\|\\|\\ohat_i\\|\\|_2^2$ |\n",
+    "| {class}`TikhonovSolver`          | One matrix regularizer for all $\\ohat_i$         | $\\|\\|\\bfGamma\\Ohat\\trp\\|\\|_F^2$                |\n",
+    "| {class}`TikhonovDecoupledSolver` | Different matrix regularizers for each $\\ohat_i$ | $\\sum_{i=1}^{r}\\|\\|\\bfGamma_i\\ohat_i\\|\\|_2^2$  |"
    ]
   },
   {
@@ -373,7 +371,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Ohat_L2 = l2solver.predict()\n",
+    "Ohat_L2 = l2solver.solve()\n",
     "l2solver.residual(Ohat_L2)"
    ]
   },
@@ -396,7 +394,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Ohat_L2d = l2dsolver.predict()\n",
+    "Ohat_L2d = l2dsolver.solve()\n",
     "l2dsolver.residual(Ohat_L2d)"
    ]
   },
@@ -420,7 +418,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Ohat_tik = tiksolver.predict()\n",
+    "Ohat_tik = tiksolver.solve()\n",
     "tiksolver.residual(Ohat_tik)"
    ]
   },
@@ -443,7 +441,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Ohat_tik = tiksolver.predict()\n",
+    "Ohat_tik = tiksolver.solve()\n",
     "tiksolver.residual(Ohat_tik)"
    ]
   },
@@ -458,6 +456,83 @@
     "tikdsolver = opinf.lstsq.TikhonovDecoupledSolver(regularizer=diags)\n",
     "tikdsolver.fit(D, Z)\n",
     "print(tikdsolver)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Truncated SVD"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The {class}`TruncatedSVDSolver` class approximates the solution to the ordinary least-squares problem {eq}`eq:lstsq:plain` by solving the related problem\n",
+    "\n",
+    "$$\n",
+    "\\begin{aligned}\n",
+    "    \\argmin_{\\Ohat}\\|\\tilde{\\D}\\Ohat\\trp - \\Z\\trp\\|_{F}^{2}\n",
+    "\\end{aligned}\n",
+    "$$\n",
+    "\n",
+    "where $\\tilde{\\D}$ is the best rank-$d'$ approximation of $\\D$ for some given $d' < \\min(k,d)$, i.e.,\n",
+    "\n",
+    "$$\n",
+    "\\begin{aligned}\n",
+    "    \\tilde{D}\n",
+    "    = \\argmin_{\\D' \\in \\RR^{k \\times d}}\n",
+    "    \\|\\D' - \\D\\|_{F}\n",
+    "    \\quad\\textrm{such that}\\quad\n",
+    "    \\operatorname{rank}(\\D') = d'.\n",
+    "\\end{aligned}\n",
+    "$$\n",
+    "\n",
+    "This approach is [related to Tikhonov regularization](https://math.stackexchange.com/questions/1084677/tikhonov-regularization-vs-truncated-svd) and is based on the [truncated singular value decomposition](https://en.wikipedia.org/wiki/Singular_value_decomposition#Truncated_SVD) of the data matrix $\\D$.\n",
+    "The optimization residual is guaranteed to be higher than when using the full SVD as in {class}`PlainSolver`, but the condition number of the truncated SVD system is lower than that of the original system.\n",
+    "Truncation can play a similar role to regularization, but the hyperparameter here (the number of columns to use) is an integer, whereas the regularization hyperparameter $\\lambda$ for {class}`L2Solver` may be any positive number."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tsvdsolver = opinf.lstsq.TruncatedSVDSolver(-2)\n",
+    "tsvdsolver.fit(D, Z)\n",
+    "print(tsvdsolver)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Ohat = tsvdsolver.solve()\n",
+    "tsvdsolver.residual(Ohat)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Change the number of columns used without recomputing the SVD.\n",
+    "tsvdsolver.num_svdmodes = 8\n",
+    "print(tsvdsolver)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tsvdsolver.residual(tsvdsolver.solve())"
    ]
   },
   {
@@ -510,7 +585,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Ohat_total = totalsolver.predict()\n",
+    "Ohat_total = totalsolver.solve()\n",
     "totalsolver.residual(Ohat_total)"
    ]
   },
@@ -547,7 +622,7 @@
     "        # Process / store hyperparameters here.\n",
     "\n",
     "    # Required methods --------------------------------------------------------\n",
-    "    def predict(self):\n",
+    "    def solve(self):\n",
     "        \"\"\"Solve the regression and return the operator matrix.\"\"\"\n",
     "        raise NotImplementedError\n",
     "\n",
@@ -615,7 +690,7 @@
     "        super().__init__()\n",
     "        self.options = dict(maxiter=maxiter, atol=atol)\n",
     "\n",
-    "    def predict(self):\n",
+    "    def solve(self):\n",
     "        \"\"\"Solve the regression and return the operator matrix.\"\"\"\n",
     "        # Allocate space for the operator matrix entries.\n",
     "        Ohat = np.empty((self.r, self.d))\n",
@@ -643,17 +718,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "solver = NNSolver()\n",
-    "solver.verify()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "solver.fit(D, Z)\n",
+    "solver = NNSolver().fit(D, Z)\n",
     "print(solver)"
    ]
   },
@@ -663,7 +728,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Ohat_nn = solver.predict()\n",
+    "solver.verify()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Ohat_nn = solver.solve()\n",
     "print(f\"{Ohat_nn.shape=}\")\n",
     "\n",
     "# Check that the entries of the operator matrix are nonnegative.\n",

--- a/docs/source/api/missing.rst
+++ b/docs/source/api/missing.rst
@@ -134,4 +134,5 @@ lstsq.ipynb
    L2DecoupledSolver
    TikhonovSolver
    TikhonovDecoupledSolver
+   TruncatedSVDSolver
    TotalLeastSquaresSolver

--- a/docs/source/api/pre.ipynb
+++ b/docs/source/api/pre.ipynb
@@ -74,6 +74,7 @@
     ":::\n",
     "\n",
     "You can [download the data here](https://github.com/Willcox-Research-Group/rom-operator-inference-Python3/raw/data/pre_example.npy) to repeat the experiments.\n",
+    "The full dataset is available [here](https://doi.org/10.7302/nj7w-j319).\n",
     "::::"
    ]
   },

--- a/docs/source/opinf/changelog.md
+++ b/docs/source/opinf/changelog.md
@@ -5,6 +5,16 @@
 New versions may introduce substantial new features or API adjustments.
 :::
 
+## Version 0.5.7
+
+Updates to `opinf.lstsq`:
+
+- New `TruncatedSVDSolver` class.
+- `predict()` has been renamed `solve()` for `opinf.lstsq` solver classes to not clash with `predict()` from `opinf.roms` / `opinf.models` classes.
+- `solve()` always returns a two-dimensional array, even if $r = 1$.
+
+Various small improvements to tests and documentation.
+
 ## Version 0.5.6
 
 Added public templates to `opinf.operators`:
@@ -14,9 +24,7 @@ Added public templates to `opinf.operators`:
 - `ParametricOperatorTemplate` for general parametric operators.
 - `ParametricOpInfOperator` for parametric operators that can be learned through Operator Inference.
 
-Also added `opinf.ddt.InterpolationDerivativeEstimator` and made various improvements to the API documentation.
-
-Also made various updates for compatibility with [NumPy 2.0.0](https://numpy.org/doc/stable/release/2.0.0-notes.html).
+Also added a new `opinf.ddt.InterpolationDerivativeEstimator` class and made various small changes for compatibility with [NumPy 2.0.0](https://numpy.org/doc/stable/release/2.0.0-notes.html).
 
 ## Version 0.5.5
 

--- a/src/opinf/__init__.py
+++ b/src/opinf/__init__.py
@@ -7,7 +7,7 @@ GitHub:
     https://github.com/Willcox-Research-Group/rom-operator-inference-Python3
 """
 
-__version__ = "0.5.6"
+__version__ = "0.5.7"
 
 from . import (
     basis,

--- a/src/opinf/lstsq/__init__.py
+++ b/src/opinf/lstsq/__init__.py
@@ -2,5 +2,6 @@
 r"""Solvers for Operator Inference least-squares problems."""
 
 from ._base import *
+from ._tsvd import *
 from ._tikhonov import *
 from ._total import *

--- a/src/opinf/lstsq/_base.py
+++ b/src/opinf/lstsq/_base.py
@@ -181,7 +181,7 @@ class SolverTemplate(abc.ABC):
         return self
 
     @abc.abstractmethod
-    def predict(self) -> np.ndarray:  # pragma: no cover
+    def solve(self) -> np.ndarray:  # pragma: no cover
         r"""Solve the Operator Inference regression.
 
         Returns
@@ -295,12 +295,12 @@ class SolverTemplate(abc.ABC):
     def verify(self):
         """Verify the solver.
 
-        If the solver is already trained, check :meth:`predict()`,
+        If the solver is already trained, check :meth:`solve()`,
         :meth:`copy()`, and (if implemented) :meth:`save()` and :meth:`load()`.
         If the solver is not trained, do nothing.
         """
         if self.data_matrix is None:
-            return print("cannot verify predict() before calling fit()")
+            return print("cannot verify solve() before calling fit()")
 
         tempfile = "_solververification.h5"
 
@@ -318,24 +318,24 @@ class SolverTemplate(abc.ABC):
                 raise errors.VerificationError(
                     f"{operation} does not preserve problem dimensions"
                 )
-            if not np.allclose(obj2.predict(), Ohat1):
+            if not np.allclose(obj2.solve(), Ohat1):
                 raise errors.VerificationError(
-                    f"{operation} does not preserve the result of predict()"
+                    f"{operation} does not preserve the result of solve()"
                 )
 
         try:
-            # Verify predict().
-            Ohat = self.predict()
+            # Verify solve().
+            Ohat = self.solve()
             if (shape1 := Ohat.shape) != (shape2 := (self.r, self.d)):
                 raise errors.VerificationError(
-                    "predict() did not return array of shape (r, d) "
+                    "solve() did not return array of shape (r, d) "
                     f"(expected {shape2}, got {shape1})"
                 )
 
             # Verify copy().
             self2 = _make_copy(self)
             _check_equality(self, self2, Ohat, "copy()")
-            print("predict() is consistent with problem dimensions")
+            print("solve() is consistent with problem dimensions")
 
             # Verify save()/load().
             try:
@@ -407,7 +407,7 @@ class PlainSolver(SolverTemplate):
             )
         return self
 
-    def predict(self):
+    def solve(self):
         r"""Solve the Operator Inference regression via
         :func:`scipy.linalg.lstsq()`.
 

--- a/src/opinf/lstsq/_base.py
+++ b/src/opinf/lstsq/_base.py
@@ -151,7 +151,7 @@ class SolverTemplate(abc.ABC):
         return ", ".join([f"{key}={repr(val)}" for key, val in opts.items()])
 
     # Main methods -----------------------------------------------------------
-    def fit(self, data_matrix, lhs_matrix):
+    def fit(self, data_matrix: np.ndarray, lhs_matrix: np.ndarray):
         r"""Verify dimensions and save the data matrices.
 
         Parameters
@@ -204,7 +204,7 @@ class SolverTemplate(abc.ABC):
         return np.linalg.cond(self.data_matrix)
 
     @_require_trained
-    def residual(self, Ohat: np.ndarray):
+    def residual(self, Ohat: np.ndarray) -> np.ndarray:
         r"""Compute the residual of the :math:`2`-norm regression objective for
         each row of the given operator matrix.
 
@@ -420,7 +420,7 @@ class PlainSolver(SolverTemplate):
         return results[0].T
 
     # Persistence -------------------------------------------------------------
-    def save(self, savefile, overwrite=False):
+    def save(self, savefile: str, overwrite: bool = False):
         """Serialize the solver, saving it in HDF5 format.
         The model can be recovered with the :meth:`load()` class method.
 

--- a/src/opinf/lstsq/_tikhonov.py
+++ b/src/opinf/lstsq/_tikhonov.py
@@ -263,7 +263,7 @@ class L2Solver(_BaseRegularizedSolver):
         return self
 
     @_require_trained
-    def predict(self):
+    def solve(self):
         r"""Solve the Operator Inference regression.
 
         Returns
@@ -645,7 +645,7 @@ class TikhonovSolver(_BaseRegularizedSolver):
         return self
 
     @_require_trained
-    def predict(self):
+    def solve(self):
         r"""Solve the Operator Inference regression.
 
         Returns
@@ -848,7 +848,7 @@ class TikhonovDecoupledSolver(TikhonovSolver):
 
     # Main methods ------------------------------------------------------------
     @_require_trained
-    def predict(self):
+    def solve(self):
         r"""Solve the Operator Inference regression.
 
         Returns

--- a/src/opinf/lstsq/_tikhonov.py
+++ b/src/opinf/lstsq/_tikhonov.py
@@ -52,7 +52,7 @@ class _BaseRegularizedSolver(SolverTemplate):
         raise NotImplementedError
 
     # Main methods ------------------------------------------------------------
-    def fit(self, data_matrix, lhs_matrix):
+    def fit(self, data_matrix: np.ndarray, lhs_matrix: np.ndarray):
         r"""Verify dimensions and save the data matrices.
 
         Parameters
@@ -73,14 +73,14 @@ class _BaseRegularizedSolver(SolverTemplate):
 
     # Post-processing ---------------------------------------------------------
     @abc.abstractmethod
-    def regcond(self):  # pragma: no cover
+    def regcond(self) -> float:  # pragma: no cover
         r"""Compute the :math:`2`-norm condition number of the regularized
         data matrix :math:`[~\D\trp~~\bfGamma\trp~]\trp.`
         """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def regresidual(self, Ohat):  # pragma: no cover
+    def regresidual(self, Ohat: np.ndarray) -> np.ndarray:  # pragma: no cover
         """Compute the residual of the regularized regression problem."""
         raise NotImplementedError
 
@@ -241,7 +241,7 @@ class L2Solver(_BaseRegularizedSolver):
         return start + f"\n  SVD solver: scipy.linalg.svd({kwargs})"
 
     # Main methods ------------------------------------------------------------
-    def fit(self, data_matrix, lhs_matrix):
+    def fit(self, data_matrix: np.ndarray, lhs_matrix: np.ndarray):
         r"""Verify dimensions and compute the singular value decomposition of
         the data matrix in preparation to solve the least-squares problem.
 
@@ -263,7 +263,7 @@ class L2Solver(_BaseRegularizedSolver):
         return self
 
     @_require_trained
-    def solve(self):
+    def solve(self) -> np.ndarray:
         r"""Solve the Operator Inference regression.
 
         Returns
@@ -284,7 +284,7 @@ class L2Solver(_BaseRegularizedSolver):
         return self._svals.max() / self._svals.min()
 
     @_require_trained
-    def regcond(self):
+    def regcond(self) -> float:
         r"""Compute the :math:`2`-norm condition number of the regularized
         data matrix :math:`[~\D\trp~~\lambda\I~]\trp.`
 
@@ -324,7 +324,7 @@ class L2Solver(_BaseRegularizedSolver):
         return residual + (self.regularizer**2 * np.sum(Ohat**2, axis=-1))
 
     # Persistence -------------------------------------------------------------
-    def save(self, savefile, overwrite=False):
+    def save(self, savefile: str, overwrite: bool = False):
         """Serialize the solver, saving it in HDF5 format.
         The model can be recovered with the :meth:`load()` class method.
 
@@ -431,7 +431,7 @@ class L2DecoupledSolver(L2Solver):
             self._check_regularizer_shape()
 
     # Main methods ------------------------------------------------------------
-    def fit(self, data_matrix, lhs_matrix):
+    def fit(self, data_matrix: np.ndarray, lhs_matrix: np.ndarray):
         r"""Verify dimensions and compute the singular value decomposition of
         the data matrix in preparation to solve the least-squares problem.
 
@@ -449,7 +449,7 @@ class L2DecoupledSolver(L2Solver):
 
     # Post-processing ---------------------------------------------------------
     @_require_trained
-    def regcond(self):
+    def regcond(self) -> float:
         r"""Compute the :math:`2`-norm condition number of each regularized
         data matrix, :math:`[~\D\trp~~\lambda_i\I~]\trp` for
         :math:`i = 1, \ldots, r`.
@@ -462,7 +462,7 @@ class L2DecoupledSolver(L2Solver):
         svals2 = self._svals**2 + self.regularizer.reshape((-1, 1)) ** 2
         return np.sqrt(svals2.max(axis=1) / svals2.min(axis=1))
 
-    def regresidual(self, Ohat):
+    def regresidual(self, Ohat: np.ndarray) -> np.ndarray:
         r"""Compute the residual of the regularized regression objective for
         each row of the given operator matrix.
 
@@ -620,7 +620,7 @@ class TikhonovSolver(_BaseRegularizedSolver):
         self.__method = method
 
     # Main routines -----------------------------------------------------------
-    def fit(self, data_matrix, lhs_matrix):
+    def fit(self, data_matrix: np.ndarray, lhs_matrix: np.ndarray):
         r"""Verify dimensions and precompute quantities in preparation to
         solve the least-squares problem.
 
@@ -645,7 +645,7 @@ class TikhonovSolver(_BaseRegularizedSolver):
         return self
 
     @_require_trained
-    def solve(self):
+    def solve(self) -> np.ndarray:
         r"""Solve the Operator Inference regression.
 
         Returns
@@ -663,7 +663,7 @@ class TikhonovSolver(_BaseRegularizedSolver):
 
     # Post-processing ---------------------------------------------------------
     @_require_trained
-    def regcond(self):
+    def regcond(self) -> float:
         r"""Compute the :math:`2`-norm condition number of the regularized
         data matrix :math:`[~\D\trp~~\bfGamma\trp~]\trp.`
 
@@ -701,7 +701,7 @@ class TikhonovSolver(_BaseRegularizedSolver):
         residual = self.residual(Ohat)
         return residual + np.sum((self.regularizer @ Ohat.T) ** 2, axis=0)
 
-    def save(self, savefile, overwrite=False):
+    def save(self, savefile: str, overwrite: bool = False):
         """Serialize the solver, saving it in HDF5 format.
         The model can be recovered with the :meth:`load()` class method.
 
@@ -848,7 +848,7 @@ class TikhonovDecoupledSolver(TikhonovSolver):
 
     # Main methods ------------------------------------------------------------
     @_require_trained
-    def solve(self):
+    def solve(self) -> np.ndarray:
         r"""Solve the Operator Inference regression.
 
         Returns
@@ -870,7 +870,7 @@ class TikhonovDecoupledSolver(TikhonovSolver):
 
     # Post-processing ---------------------------------------------------------
     @_require_trained
-    def regcond(self):
+    def regcond(self) -> float:
         r"""Compute the :math:`2`-norm condition number of each regularized
         data matrix :math:`[~\D\trp~~\bfGamma_i\trp~]\trp,~~i = 1, \ldots, r`.
 
@@ -887,7 +887,7 @@ class TikhonovDecoupledSolver(TikhonovSolver):
         )
 
     @_require_trained
-    def regresidual(self, Ohat):
+    def regresidual(self, Ohat: np.ndarray) -> np.ndarray:
         r"""Compute the residual of the regularized regression objective for
         each row of the given operator matrix.
 

--- a/src/opinf/lstsq/_total.py
+++ b/src/opinf/lstsq/_total.py
@@ -107,7 +107,7 @@ class TotalLeastSquaresSolver(SolverTemplate):
         return self
 
     @_require_trained
-    def predict(self):
+    def solve(self):
         r"""Return the total least-squares solution to the Operator Inference
         regression.
 

--- a/src/opinf/lstsq/_total.py
+++ b/src/opinf/lstsq/_total.py
@@ -57,11 +57,11 @@ class TotalLeastSquaresSolver(SolverTemplate):
 
     # Properties --------------------------------------------------------------
     @property
-    def options(self):
+    def options(self) -> dict:
         """Keyword arguments for :func:`scipy.linalg.svd()`."""
         return self.__options
 
-    def __str__(self):
+    def __str__(self) -> str:
         """String representation: dimensions + solver options."""
         start = SolverTemplate.__str__(self)
         if self.data_matrix is not None:
@@ -75,7 +75,7 @@ class TotalLeastSquaresSolver(SolverTemplate):
         return start + f"\n  SVD solver: scipy.linalg.svd({kwargs})"
 
     # Main methods ------------------------------------------------------------
-    def fit(self, data_matrix, lhs_matrix):
+    def fit(self, data_matrix: np.ndarray, lhs_matrix: np.ndarray):
         r"""Verify dimensions, compute the singular value decomposition of
         the data matrix, and solve the problem.
 
@@ -107,7 +107,7 @@ class TotalLeastSquaresSolver(SolverTemplate):
         return self
 
     @_require_trained
-    def solve(self):
+    def solve(self) -> np.ndarray:
         r"""Return the total least-squares solution to the Operator Inference
         regression.
 
@@ -136,7 +136,7 @@ class TotalLeastSquaresSolver(SolverTemplate):
         return self._norm_of_errors
 
     # Persistence -------------------------------------------------------------
-    def save(self, savefile, overwrite=False):
+    def save(self, savefile: str, overwrite: bool = False):
         """Serialize the solver, saving it in HDF5 format.
         The model can be recovered with the :meth:`load()` class method.
 

--- a/src/opinf/lstsq/_total.py
+++ b/src/opinf/lstsq/_total.py
@@ -83,13 +83,9 @@ class TotalLeastSquaresSolver(SolverTemplate):
         ----------
         data_matrix : (k, d) ndarray
             Data matrix :math:`\D`.
-        lhs_matrix : (r, k) ndarray
+        lhs_matrix : (r, k) or (k,) ndarray
             "Left-hand side" data matrix :math:`\Z` (not its transpose!).
             If one-dimensional, assume :math:`r = 1`.
-
-        Returns
-        -------
-        self
         """
         SolverTemplate.fit(self, data_matrix, lhs_matrix)
 

--- a/src/opinf/lstsq/_tsvd.py
+++ b/src/opinf/lstsq/_tsvd.py
@@ -106,8 +106,8 @@ class TruncatedSVDSolver(SolverTemplate):
             )
             lines = start.split("\n")
             lines.insert(
-                4,
-                f"    New condition number: {self.tcond():.4e}",
+                3,
+                f"    Truncation condition number: {self.tcond():.4e}",
             )
             start = "\n".join(lines)
         return f"{start}\n  " + "\n  ".join(out)
@@ -140,7 +140,7 @@ class TruncatedSVDSolver(SolverTemplate):
         return self
 
     @_require_trained
-    def predict(self):
+    def solve(self):
         r"""Solve the Operator Inference regression.
 
         Returns

--- a/src/opinf/lstsq/_tsvd.py
+++ b/src/opinf/lstsq/_tsvd.py
@@ -27,7 +27,7 @@ class TruncatedSVDSolver(SolverTemplate):
     :math:`\D` for a given :math:`d' \le \operatorname{rank}(\D)`, i.e.,
 
     .. math ::
-       \tilde{D}
+       \tilde{\D}
        = \argmin_{\D' \in \RR^{k \times d}}\|\D' - \D\|_{F}
        \quad\textrm{such that}\quad
        \operatorname{rank}(\D') = d'.
@@ -126,7 +126,6 @@ class TruncatedSVDSolver(SolverTemplate):
 
         Phi, svals, PsiT = la.svd(self.data_matrix, **self.options)
         self._svals = svals
-        self._Phi = Phi
         self._ZPhi = self.lhs_matrix @ Phi
         self._SinvPsiT = PsiT / svals.reshape((-1, 1))
 

--- a/src/opinf/lstsq/_tsvd.py
+++ b/src/opinf/lstsq/_tsvd.py
@@ -1,0 +1,225 @@
+# lstsq/_total.py
+"""Operator Inference truncated singular value decomposition solver."""
+
+__all__ = [
+    "TruncatedSVDSolver",
+]
+
+import types
+import warnings
+import numpy as np
+import scipy.linalg as la
+
+from .. import errors, utils
+from ._base import SolverTemplate, _require_trained
+
+
+class TruncatedSVDSolver(SolverTemplate):
+    r"""Solve the Frobenius-norm ordinary least-squares problem with
+    truncated singular value decomposition.
+
+    That is, approximately solve
+
+    .. math::
+       \argmin_{\Ohat}\|\D\Ohat\trp - \Z\trp\|_F^2
+
+    by taking the singular value decomposition (SVD) of the data matrix
+    :math:`\D` and truncating it to a specified number of modes :math:`n`.
+
+    If :math:`\D = \bfPhi\bfSigma\bfPsi\trp`, then defining
+
+    .. math::
+       \bfPhi' = \bfPhi_{:n, :}
+       \quad
+       \bfSigma' = \bfSigma_{:n, :n}
+       \quad
+       \bfPsi' = \bfPsi_{:n, :},
+
+    the solution is given by
+    :math:`\Ohat\trp = \bfPsi'(\bfSigma')^{-1}(\bfPhi')\trp\Z\trp` (i.e.,
+    :math:`\Ohat = \Z\bfPhi'(\bfSigma')^{-1}(\bfPsi')\trp`).
+
+    Parameters
+    ----------
+    num_svdmodes : int or None
+        Number of singular value decomposition modes to retain.
+        If ``None``, use all available modes (no truncation).
+        If a negative integer, use ``k - abs(num_svdmodes)`` modes where
+        ``k`` is the number of available modes.
+    lapack_driver : str
+        LAPACK routine for computing the singular value decomposition.
+        See :func:`scipy.linalg.svd()`.
+    """
+
+    def __init__(self, num_svdmodes: int, lapack_driver: str = "gesdd"):
+        """Set the number of SVD columns to keep."""
+        SolverTemplate.__init__(self)
+        self.num_svdmodes = num_svdmodes
+        self.__options = types.MappingProxyType(
+            dict(full_matrices=False, lapack_driver=lapack_driver)
+        )
+
+    # Properties --------------------------------------------------------------
+    @property
+    def num_svdmodes(self) -> int:
+        """Number of singular value decomposition modes to retain."""
+        return self.__nmodes
+
+    @num_svdmodes.setter
+    def num_svdmodes(self, nmodes: int):
+        """Set the number of columns."""
+        if nmodes is None:
+            self.__nmodes = self.max_modes
+            return
+
+        if not isinstance(nmodes, int):
+            raise TypeError("num_svdmodes must be an integer")
+
+        if self.data_matrix is not None:
+            k = self.max_modes
+            if nmodes <= 0:
+                nmodes = k + nmodes
+            if nmodes > k:
+                raise ValueError(f"only {k} SVD modes available")
+        self.__nmodes = nmodes
+
+    @property
+    def options(self):
+        """Keyword arguments for :func:`scipy.linalg.svd()`.
+        These cannot be changed after instantiation.
+        """
+        return self.__options
+
+    @property
+    def max_modes(self):
+        """Maximum number of singular value decomposition modes available."""
+        return None if self.data_matrix is None else self._ZPhi.shape[1]
+
+    def __str__(self):
+        """String representation: dimensions + solver options."""
+        start = SolverTemplate.__str__(self)
+        kwargs = self._print_kwargs(self.options)
+        out = [f"SVD solver: scipy.linalg.svd({kwargs})"]
+        if self.data_matrix is not None:
+            out.append(
+                f"using {self.num_svdmodes} of {self.max_modes} SVD modes"
+            )
+            startlines = start.split("\n")
+            startlines.insert(
+                3,
+                f"    New condition number: {self.tcond():.4e}",
+            )
+            start = "\n".join(startlines)
+        return f"{start}\n  " + "\n  ".join(out)
+
+    # Main methods ------------------------------------------------------------
+    def fit(self, data_matrix, lhs_matrix):
+        """Save data matrices and prepare to solve the regression problem."""
+        SolverTemplate.fit(self, data_matrix, lhs_matrix)
+
+        Phi, svals, PsiT = la.svd(self.data_matrix, **self.options)
+        self._svals = svals
+        self._ZPhi = self.lhs_matrix @ Phi
+        self._PsiT = PsiT
+
+        # Reset num_svdmodes.
+        k = self._ZPhi.shape[1]
+        if (n := self.num_svdmodes) is None:
+            n = k
+        if n <= 0:
+            n = k + n
+        if n > k:
+            warnings.warn(
+                f"only {k} SVD modes available, "
+                f"setting num_svdmodes=k (was {n})",
+                errors.OpInfWarning,
+            )
+            n = k
+        self.__nmodes = n
+
+        return self
+
+    @_require_trained
+    def predict(self):
+        r"""Solve the Operator Inference regression.
+
+        Returns
+        -------
+        Ohat : (r, d) or (d,) ndarray
+            Operator matrix :math:`\Ohat` (not its transpose!).
+            If :math:`r = 1`, a one-dimensional array is returned.
+        """
+        n = self.num_svdmodes
+        Ohat = (self._ZPhi[:, :n] * (1 / self._svals[:n])) @ self._PsiT[:n, :]
+        return np.ravel(Ohat) if self.r == 1 else Ohat
+
+    # Post-processing ---------------------------------------------------------
+    @_require_trained
+    def tcond(self):
+        r"""Compute the effective :math:`2`-norm condition number of the data
+        matrix :math:`\D` using only the retained SVD modes.
+        """
+        return self._svals[0] / self._svals[self.num_svdmodes - 1]
+
+    # Persistence -------------------------------------------------------------
+    def save(self, savefile, overwrite=False):
+        """Serialize the solver, saving it in HDF5 format.
+        The model can be recovered with the :meth:`load()` class method.
+
+        Parameters
+        ----------
+        savefile : str
+            File to save to, with extension ``.h5`` (HDF5).
+        overwrite : bool
+            If ``True`` and the specified ``savefile`` already exists,
+            overwrite the file. If ``False`` (default) and the specified
+            ``savefile`` already exists, raise an error.
+        """
+        with utils.hdf5_savehandle(savefile, overwrite) as hf:
+            self._save_dict(hf, "options")
+            hf.create_dataset("num_svdmodes", data=[self.num_svdmodes])
+            if self.data_matrix is not None:
+                hf.create_dataset("data_matrix", data=self.data_matrix)
+                hf.create_dataset("lhs_matrix", data=self.lhs_matrix)
+                for attr in ("_svals", "_ZPhi", "_PsiT"):
+                    hf.create_dataset(attr, data=getattr(self, attr))
+
+    @classmethod
+    def load(cls, loadfile: str):
+        """Load a serialized solver from an HDF5 file, created previously from
+        the :meth:`save()` method.
+
+        Parameters
+        ----------
+        loadfile : str
+            Path to the file where the model was stored via :meth:`save()`.
+
+        Returns
+        -------
+        solver : TruncatedSVDSolver
+            Loaded solver.
+        """
+        with utils.hdf5_loadhandle(loadfile) as hf:
+            options = cls._load_dict(hf, "options")
+            num_svdmodes = int(hf["num_svdmodes"][0])
+            solver = cls(num_svdmodes, lapack_driver=options["lapack_driver"])
+            if "data_matrix" in hf:
+                D = hf["data_matrix"][:]
+                Z = hf["lhs_matrix"][:]
+                SolverTemplate.fit(solver, D, Z)
+                for attr in ("_svals", "_ZPhi", "_PsiT"):
+                    setattr(solver, attr, hf[attr][:])
+        return solver
+
+    def copy(self):
+        """Make a copy of the solver."""
+        solver = self.__class__(
+            num_svdmodes=self.num_svdmodes,
+            lapack_driver=self.options["lapack_driver"],
+        )
+        if self.data_matrix is not None:
+            SolverTemplate.fit(solver, self.data_matrix, self.lhs_matrix)
+            solver._svals = self._svals
+            solver._ZPhi = self._ZPhi
+            solver._PsiT = self._PsiT
+        return solver

--- a/src/opinf/lstsq/_tsvd.py
+++ b/src/opinf/lstsq/_tsvd.py
@@ -76,11 +76,11 @@ class TruncatedSVDSolver(SolverTemplate):
             raise TypeError("num_svdmodes must be an integer")
 
         if self.data_matrix is not None:
-            k = self.max_modes
+            d = self.max_modes
             if nmodes <= 0:
-                nmodes = k + nmodes
-            if nmodes > k:
-                raise ValueError(f"only {k} SVD modes available")
+                nmodes = d + nmodes
+            if nmodes > d:
+                raise ValueError(f"only {d} SVD modes available")
         self.__nmodes = nmodes
 
     @property
@@ -104,12 +104,12 @@ class TruncatedSVDSolver(SolverTemplate):
             out.append(
                 f"using {self.num_svdmodes} of {self.max_modes} SVD modes"
             )
-            startlines = start.split("\n")
-            startlines.insert(
-                3,
+            lines = start.split("\n")
+            lines.insert(
+                4,
                 f"    New condition number: {self.tcond():.4e}",
             )
-            start = "\n".join(startlines)
+            start = "\n".join(lines)
         return f"{start}\n  " + "\n  ".join(out)
 
     # Main methods ------------------------------------------------------------
@@ -123,18 +123,18 @@ class TruncatedSVDSolver(SolverTemplate):
         self._PsiT = PsiT
 
         # Reset num_svdmodes.
-        k = self._ZPhi.shape[1]
+        d = self._ZPhi.shape[1]
         if (n := self.num_svdmodes) is None:
-            n = k
+            n = d
         if n <= 0:
-            n = k + n
-        if n > k:
+            n = d + n
+        if n > d:
             warnings.warn(
-                f"only {k} SVD modes available, "
-                f"setting num_svdmodes=k (was {n})",
+                f"only {d} SVD modes available, "
+                f"setting num_svdmodes={d} (was {n})",
                 errors.OpInfWarning,
             )
-            n = k
+            n = d
         self.__nmodes = n
 
         return self

--- a/src/opinf/models/mono/_base.py
+++ b/src/opinf/models/mono/_base.py
@@ -269,10 +269,10 @@ class _Model(abc.ABC):
             else:
                 raise ValueError("if a scalar, solver must be nonnegative")
 
-        # Light validation: must be instance w/ fit(), predict().
+        # Light validation: must be instance w/ fit(), solve().
         if isinstance(solver, type):
             raise TypeError("solver must be an instance, not a class")
-        for mtd in "fit", "predict":
+        for mtd in "fit", "solve":
             if not hasattr(solver, mtd) or not callable(getattr(solver, mtd)):
                 warnings.warn(
                     f"solver should have a '{mtd}()' method",

--- a/src/opinf/models/mono/_nonparametric.py
+++ b/src/opinf/models/mono/_nonparametric.py
@@ -245,7 +245,7 @@ class _NonparametricModel(_Model):
             return self
 
         # Execute non-intrusive learning.
-        self._extract_operators(np.atleast_2d(self.solver.predict()))
+        self._extract_operators(self.solver.solve())
 
     def fit(self, states, lhs, inputs=None):
         r"""Learn the model operators from data.

--- a/src/opinf/models/mono/_parametric.py
+++ b/src/opinf/models/mono/_parametric.py
@@ -312,7 +312,7 @@ class _ParametricModel(_Model):
             return self
 
         # Execute non-intrusive learning.
-        self._extract_operators(np.atleast_2d(self.solver.predict()))
+        self._extract_operators(self.solver.solve())
 
     def fit(self, parameters, states, lhs, inputs=None):
         r"""Learn the model operators from data.

--- a/tests/lstsq/test_base.py
+++ b/tests/lstsq/test_base.py
@@ -47,7 +47,7 @@ class TestSolverTemplate:
     class Dummy(opinf.lstsq._base.SolverTemplate):
         """Instantiable version of SolverTemplate."""
 
-        def predict(self):
+        def solve(self):
             return np.ones((self.r, self.d))
 
     def test_properties(self):
@@ -240,10 +240,10 @@ class TestSolverTemplate:
         _single(Dummy2, "Dummy2.copy() returned object of type 'int'")
 
         class Dummy5(self.Dummy):
-            def predict(self):
+            def solve(self):
                 return np.empty((1, 1))
 
-        _single(Dummy5, "predict() did not return array of shape (r, d)")
+        _single(Dummy5, "solve() did not return array of shape (r, d)")
 
         class Dummy6(self.Dummy):
             def copy(self):
@@ -255,10 +255,10 @@ class TestSolverTemplate:
         _single(Dummy6, "copy() does not preserve problem dimensions")
 
         class Dummy7(self.Dummy):
-            def predict(self):
+            def solve(self):
                 return np.random.random((self.r, self.d))
 
-        _single(Dummy7, "copy() does not preserve the result of predict()")
+        _single(Dummy7, "copy() does not preserve the result of solve()")
 
         class Dummy8(self.Dummy):
             def save(self, savefile, overwrite=False):
@@ -309,8 +309,8 @@ class TestPlainSolver:
 
         repr(solver)
 
-    def test_predict(self, k=20, d=11, r=3):
-        """Test predict()."""
+    def test_solve(self, k=20, d=11, r=3):
+        """Test solve()."""
         # Set up and manually solve a least-squares problem.
         D = np.random.standard_normal((k, d))
         Z = np.random.random((r, k))
@@ -319,7 +319,7 @@ class TestPlainSolver:
 
         # Check the least-squares solution.
         solver = self.Solver().fit(D, Z)
-        Ohat = solver.predict()
+        Ohat = solver.solve()
         assert np.allclose(Ohat, Ohat_true)
 
     def test_save(self, k=6, d=4, r=2, outfile="_plainsolversavetest.h5"):

--- a/tests/lstsq/test_tikhonov.py
+++ b/tests/lstsq/test_tikhonov.py
@@ -87,7 +87,6 @@ class TestL2Solver:
         solver = self.Solver(1)
         A = np.random.standard_normal((k, d))
         B = np.random.standard_normal((r, k))
-        solver.verify()
         solver.fit(A, B)
         solver.verify()
 
@@ -246,9 +245,10 @@ class TestL2Solver:
         for reg in [0] + np.random.uniform(0, 10, ntests).tolist():
             solver.regularizer = reg
             residual = solver.regresidual(x)
-            assert isinstance(residual, float)
+            assert isinstance(residual, np.ndarray)
+            assert residual.shape == (1,)
             ans = np.linalg.norm(A @ x - b) ** 2 + np.linalg.norm(reg * x) ** 2
-            assert np.isclose(residual, ans)
+            assert np.isclose(residual[0], ans)
 
     # Persistence -------------------------------------------------------------
     def test_save(self, k=9, d=4, r=3, outfile="_l2solversavetest.h5"):
@@ -568,9 +568,7 @@ class TestTikhonovSolver:
         A = np.random.standard_normal((k, d))
         B = np.random.standard_normal((r, k))
         solver = self.Solver(Z)
-        solver.verify(d=d, r=r)
         solver.fit(A, B)
-        solver.verify()
 
         for attr, shape in [
             ("data_matrix", (k, d)),
@@ -594,7 +592,9 @@ class TestTikhonovSolver:
         Z = np.zeros((d, d))
         Id = np.eye(d)
         solver1D = self.Solver(Z).fit(A, b)
+        solver1D.verify()
         solver2D = self.Solver(Z).fit(A, B)
+        solver2D.verify()
 
         for method in ["normal", "lstsq"]:
             # Test without regularization, b.ndim = 1.
@@ -721,9 +721,10 @@ class TestTikhonovSolver:
             P = np.random.uniform(1, 10, d)
             solver.regularizer = P
             residual = solver.regresidual(x)
-            assert isinstance(residual, float)
+            assert isinstance(residual, np.ndarray)
+            assert residual.shape == (1,)
             ans = np.linalg.norm(A @ x - b) ** 2 + np.linalg.norm(P * x) ** 2
-            assert np.isclose(residual, ans)
+            assert np.isclose(residual[0], ans)
 
     # Persistence -------------------------------------------------------------
     def test_save(self, k=9, d=4, r=3, outfile="_l2decoupledsavetest.h5"):

--- a/tests/lstsq/test_tikhonov.py
+++ b/tests/lstsq/test_tikhonov.py
@@ -16,7 +16,7 @@ class TestBaseRegularizedSolver:
     class Dummy(opinf.lstsq._tikhonov._BaseRegularizedSolver):
         """Instantiable version of _BaseRegularizedSolver."""
 
-        def predict(*args, **kwargs):
+        def solve(*args, **kwargs):
             pass
 
         @property
@@ -104,17 +104,17 @@ class TestL2Solver:
 
         repr(solver)
 
-    def test_predict(self, k=20, d=10, r=5):
-        """Test predict()."""
+    def test_solve(self, k=20, d=10, r=5):
+        """Test solve()."""
         solver1D = self.Solver(0)
         solver2D = self.Solver(0)
         A = np.random.random((k, d))
         B = np.random.random((r, k))
         b = B[0, :]
 
-        # Try predicting before fitting.
+        # Try solving before fitting.
         with pytest.raises(AttributeError) as ex:
-            solver1D.predict()
+            solver1D.solve()
         assert ex.value.args[0] == "solver not trained, call fit()"
 
         # Fit the solvers.
@@ -123,12 +123,12 @@ class TestL2Solver:
 
         # Test without regularization, b.ndim = 1.
         x1 = la.lstsq(A, b)[0]
-        x2 = solver1D.predict()
+        x2 = solver1D.solve()
         assert np.allclose(x1, x2)
 
         # Test without regularization, b.ndim = 2.
         X1 = la.lstsq(A, B.T)[0].T
-        X2 = solver2D.predict()
+        X2 = solver2D.solve()
         assert np.allclose(X1, X2)
 
         # Test with regularization, b.ndim = 1.
@@ -136,14 +136,14 @@ class TestL2Solver:
         bpad = np.concatenate((b, np.zeros(d)))
         x1 = la.lstsq(Apad, bpad)[0]
         solver1D.regularizer = 1
-        x2 = solver1D.predict()
+        x2 = solver1D.solve()
         assert np.allclose(x1, x2)
 
         # Test with regularization, b.ndim = 2.
         Bpad = np.concatenate((B.T, np.zeros((d, r))))
         X1 = la.lstsq(Apad, Bpad)[0].T
         solver2D.regularizer = 1
-        X2 = solver2D.predict()
+        X2 = solver2D.solve()
         assert np.allclose(X1, X2)
 
     # Post-processing ---------------------------------------------------------
@@ -292,7 +292,7 @@ class TestL2Solver:
         assert solver2.d == d
         assert np.all(solver2.data_matrix == D)
         assert np.all(solver2.lhs_matrix == Z)
-        assert np.allclose(solver2.predict(), solver.predict())
+        assert np.allclose(solver2.solve(), solver.solve())
 
         os.remove(outfile)
 
@@ -315,7 +315,7 @@ class TestL2Solver:
         assert solver2.d == d
         assert np.all(solver2.data_matrix == D)
         assert np.all(solver2.lhs_matrix == Z)
-        assert np.allclose(solver2.predict(), solver.predict())
+        assert np.allclose(solver2.solve(), solver.solve())
 
 
 class TestL2DecoupledSolver:
@@ -353,8 +353,8 @@ class TestL2DecoupledSolver:
         repr(solver)
 
     # Main methods ------------------------------------------------------------
-    def test_predict(self, k=20, d=10):
-        """Test predict()."""
+    def test_solve(self, k=20, d=10):
+        """Test solve()."""
         regularizers = np.array([0, 1, 3, 5])
         r = len(regularizers)
         A = np.random.random((k, d))
@@ -367,7 +367,7 @@ class TestL2DecoupledSolver:
         X1 = np.array(
             [la.lstsq(Apad, Bpad[:, i])[0] for i, Apad in enumerate(Apads)]
         )
-        X2 = solver.predict()
+        X2 = solver.solve()
         assert np.allclose(X1, X2)
 
     # Post-processing ---------------------------------------------------------
@@ -480,7 +480,7 @@ class TestL2DecoupledSolver:
         assert solver2.d == d
         assert np.all(solver2.data_matrix == D)
         assert np.all(solver2.lhs_matrix == Z)
-        assert np.allclose(solver2.predict(), solver.predict())
+        assert np.allclose(solver2.solve(), solver.solve())
 
         os.remove(outfile)
 
@@ -506,7 +506,7 @@ class TestL2DecoupledSolver:
         assert solver2.d == d
         assert np.all(solver2.data_matrix == D)
         assert np.all(solver2.lhs_matrix == Z)
-        assert np.allclose(solver2.predict(), solver.predict())
+        assert np.allclose(solver2.solve(), solver.solve())
 
 
 class TestTikhonovSolver:
@@ -582,8 +582,8 @@ class TestTikhonovSolver:
             assert isinstance(obj, np.ndarray)
             assert obj.shape == shape
 
-    def test_predict(self, k=40, d=15, r=5):
-        """Test predict()."""
+    def test_solve(self, k=40, d=15, r=5):
+        """Test solve()."""
         A = np.random.random((k, d))
         B = np.random.random((r, k))
         Bpad = np.concatenate((B.T, np.zeros((d, r))))
@@ -601,27 +601,27 @@ class TestTikhonovSolver:
             solver1D.method = method
             solver1D.regularizer = Z
             x1 = la.lstsq(A, b)[0]
-            x2 = solver1D.predict()
+            x2 = solver1D.solve()
             assert np.allclose(x1, x2)
 
             # Test without regularization, b.ndim = 2.
             solver2D.method = method
             solver2D.regularizer = Z
             X1 = la.lstsq(A, B.T)[0].T
-            X2 = solver2D.predict()
+            X2 = solver2D.solve()
             assert np.allclose(X1, X2)
 
             # Test with regularization, b.ndim = 1.
             solver1D.regularizer = Id
             Apad = np.vstack((A, Id))
             x1 = la.lstsq(Apad, bpad)[0]
-            x2 = solver1D.predict()
+            x2 = solver1D.solve()
             assert np.allclose(x1, x2)
 
             # Test with regularization, b.ndim = 2.
             solver2D.regularizer = Id
             X1 = la.lstsq(Apad, Bpad)[0].T
-            X2 = solver2D.predict()
+            X2 = solver2D.solve()
             assert np.allclose(X1, X2)
 
         # Test SVD method with a severely ill-conditioned system.
@@ -636,7 +636,7 @@ class TestTikhonovSolver:
         # No regularization.
         solver2D = self.Solver(Z, method="lstsq").fit(A, B)
         X1 = la.lstsq(A, B.T)[0].T
-        X2 = solver2D.predict()
+        X2 = solver2D.solve()
         assert np.allclose(X1, X2)
 
         # Some regularization.
@@ -644,7 +644,7 @@ class TestTikhonovSolver:
         Apad = np.vstack((A, Id))
         Bpad = np.concatenate((B.T, np.zeros((d, r))))
         X1 = la.lstsq(Apad, Bpad)[0].T
-        X2 = solver2D.predict()
+        X2 = solver2D.solve()
         assert np.allclose(X1, X2)
 
     # Post-processing ---------------------------------------------------------
@@ -772,7 +772,7 @@ class TestTikhonovSolver:
         assert solver2.d == d
         assert np.all(solver2.data_matrix == D)
         assert np.all(solver2.lhs_matrix == Z)
-        assert np.allclose(solver2.predict(), solver.predict())
+        assert np.allclose(solver2.solve(), solver.solve())
 
         os.remove(outfile)
 
@@ -798,7 +798,7 @@ class TestTikhonovSolver:
         assert solver2.d == d
         assert np.all(solver2.data_matrix == D)
         assert np.all(solver2.lhs_matrix == Z)
-        assert np.allclose(solver2.predict(), solver.predict())
+        assert np.allclose(solver2.solve(), solver.solve())
 
 
 class TestTikhonovDecoupledSolver:
@@ -843,8 +843,8 @@ class TestTikhonovDecoupledSolver:
         repr(solver)
 
     # Main methods ------------------------------------------------------------
-    def test_predict(self, k=20, d=10):
-        """Test lstsq._tikhonov.TikhonovDecoupledSolver.predict()."""
+    def test_solve(self, k=20, d=10):
+        """Test lstsq._tikhonov.TikhonovDecoupledSolver.solve()."""
         Z = np.zeros(d)
         Ps = [np.eye(d), np.full(d, 2)]
         r = len(Ps)
@@ -852,9 +852,9 @@ class TestTikhonovDecoupledSolver:
         B = np.random.random((r, k))
         solver = self.Solver(Ps)
 
-        # Try predicting before fitting.
+        # Try solving before fitting.
         with pytest.raises(AttributeError) as ex:
-            solver.predict()
+            solver.solve()
         assert ex.value.args[0] == "solver not trained, call fit()"
         solver.fit(A, B)
 
@@ -864,7 +864,7 @@ class TestTikhonovDecoupledSolver:
         xx1 = la.lstsq(Apad1, Bpad[:, 0])[0]
         xx2 = la.lstsq(Apad2, Bpad[:, 1])[0]
         X1 = np.array([xx1, xx2])
-        X2 = solver.predict()
+        X2 = solver.solve()
         assert np.allclose(X1, X2)
 
         # Test with a severely ill-conditioned system.
@@ -880,7 +880,7 @@ class TestTikhonovDecoupledSolver:
         solver = self.Solver([Z] * r).fit(A, B)
         Z = np.zeros(d)
         X1 = la.lstsq(A, B.T)[0].T
-        X2 = solver.predict()
+        X2 = solver.solve()
         assert np.allclose(X1, X2)
 
         # Some regularization.
@@ -893,7 +893,7 @@ class TestTikhonovDecoupledSolver:
             xx1 = la.lstsq(Apad1, Bpad[:, 0])[0]
             xx2 = la.lstsq(Apad2, Bpad[:, 1])[0]
             X1 = np.array([xx1, xx2])
-            X2 = solver.predict()
+            X2 = solver.solve()
             assert np.allclose(X1, X2)
 
     # Post-processing ---------------------------------------------------------
@@ -986,7 +986,7 @@ class TestTikhonovDecoupledSolver:
         assert solver2.d == d
         assert np.all(solver2.data_matrix == D)
         assert np.all(solver2.lhs_matrix == Z)
-        assert np.allclose(solver2.predict(), solver.predict())
+        assert np.allclose(solver2.solve(), solver.solve())
 
         os.remove(outfile)
 
@@ -1012,4 +1012,4 @@ class TestTikhonovDecoupledSolver:
         assert solver2.d == d
         assert np.all(solver2.data_matrix == D)
         assert np.all(solver2.lhs_matrix == Z)
-        assert np.allclose(solver2.predict(), solver.predict())
+        assert np.allclose(solver2.solve(), solver.solve())

--- a/tests/lstsq/test_total.py
+++ b/tests/lstsq/test_total.py
@@ -26,18 +26,17 @@ class TestTotalLeastSquaresSolver:
         assert isinstance(solver.error, float)
         solver.verify()
 
-    def test_predict(self, k=15, d=7, r=5):
-        """Test predict()."""
+    def test_solve(self, k=15, d=7, r=5):
+        """Test solve() via verify()."""
         D = np.random.standard_normal((k, d))
         Z = np.random.random((r, k))
         solver = self.Solver().fit(D, Z)
-        Ohat = solver.predict()
-        assert Ohat.shape == (r, d)
+        solver.verify()
 
         # One-dimensional accuracy test.
         z = Z[0]
         solver.fit(D, z)
-        ohat_TLS = solver.predict()
+        ohat_TLS = solver.solve()
         DtD = D.T @ D
         minsval = la.svdvals(np.column_stack((D, z))).min()
         A = la.solve(DtD - minsval**2 * np.eye(d), DtD, assume_a="sym")
@@ -85,7 +84,7 @@ class TestTotalLeastSquaresSolver:
         assert solver2.d == d
         assert np.all(solver2.data_matrix == D)
         assert np.all(solver2.lhs_matrix == Z)
-        assert np.all(solver2.predict() == solver.predict())
+        assert np.all(solver2.solve() == solver.solve())
 
         os.remove(outfile)
 
@@ -107,4 +106,4 @@ class TestTotalLeastSquaresSolver:
         assert solver2.d == d
         assert np.all(solver2.data_matrix == D)
         assert np.all(solver2.lhs_matrix == Z)
-        assert np.all(solver2.predict() == solver.predict())
+        assert np.all(solver2.solve() == solver.solve())

--- a/tests/lstsq/test_tsvd.py
+++ b/tests/lstsq/test_tsvd.py
@@ -1,0 +1,67 @@
+# lstsq/test_tsvd.py
+"""Tests for lstsq._tsvd.py."""
+
+import pytest
+import numpy as np
+
+import opinf
+
+
+class TestTotalLeastSquaresSolver:
+    """Test lstsq._tsvd.TruncatedSVDSolver."""
+
+    Solver = opinf.lstsq.TruncatedSVDSolver
+
+    def test_init(self):
+        """Test __init__() and properties."""
+        with pytest.raises(TypeError) as ex:
+            self.Solver("ten")
+        assert ex.value.args[0] == "num_svdmodes must be an integer"
+
+        for n in (10, -3, None):
+            solver = self.Solver(n)
+            assert solver.data_matrix is None
+            if n is None:
+                assert solver.num_svdmodes is None
+            else:
+                assert solver.num_svdmodes == n
+            assert solver.max_modes is None
+
+        repr(solver)
+
+    def test_fit(self, k=20, d=10, r=6):
+        """Test fit()."""
+        D = np.random.standard_normal((k, d))
+        Z = np.random.random((r, k))
+        nn = (n := min(D.shape)) - 2
+        solver = self.Solver(nn)
+        out = solver.fit(D, Z)
+        assert out is solver
+        assert solver.num_svdmodes == nn
+        assert solver.max_modes == n
+        repr(solver)
+        solver.verify()
+
+        with pytest.raises(ValueError) as ex:
+            solver.num_svdmodes = n * 2
+        assert ex.value.args[0] == f"only {n} SVD modes available"
+
+        solver = self.Solver(None)
+        solver.fit(D, Z)
+        assert solver.num_svdmodes == n
+
+        for nn in (0, -3):
+            solver = self.Solver(nn)
+            solver.fit(D, Z)
+            assert solver.num_svdmodes == n + nn
+            assert solver.max_modes == n
+
+        assert solver.tcond() < solver.cond()
+
+    def test_predict(self, k=15, d=7, r=5):
+        """Test predict()."""
+        D = np.random.standard_normal((k, d))
+        Z = np.random.random((r, k))
+        solver = self.Solver(min(D.shape) - 2).fit(D, Z)
+        Ohat = solver.predict()
+        assert Ohat.shape == (r, d)

--- a/tests/lstsq/test_tsvd.py
+++ b/tests/lstsq/test_tsvd.py
@@ -74,8 +74,8 @@ class TestTotalLeastSquaresSolver:
 
         assert np.isclose(solver.tcond(), solver.cond())
 
-    def test_predict(self, k=15, d=7, r=5):
-        """Test predict() via verify()."""
+    def test_solve(self, k=15, d=7, r=5):
+        """Test solve() via verify()."""
         D = np.random.standard_normal((k, d))
         Z = np.random.random((r, k))
         solver = self.Solver(min(D.shape) - 2).fit(D, Z)
@@ -83,10 +83,10 @@ class TestTotalLeastSquaresSolver:
 
         Ohat_true = la.lstsq(D, Z.T)[0].T
         resid_true = la.norm(solver.residual(Ohat_true))
-        Ohat = solver.predict()
+        Ohat = solver.solve()
         resid = la.norm(solver.residual(Ohat))
         assert resid > resid_true
 
         solver = self.Solver(None).fit(D, Z)
-        Ohat = solver.predict()
+        Ohat = solver.solve()
         assert np.allclose(Ohat, Ohat_true)

--- a/tests/models/mono/test_base.py
+++ b/tests/models/mono/test_base.py
@@ -253,9 +253,7 @@ class TestModel:
             model.solver = []
         assert len(wn) == 2
         assert wn[0].message.args[0] == "solver should have a 'fit()' method"
-        assert wn[1].message.args[0] == (
-            "solver should have a 'predict()' method"
-        )
+        assert wn[1].message.args[0] == "solver should have a 'solve()' method"
 
         model.solver = 0
         assert isinstance(model.solver, opinf.lstsq.PlainSolver)


### PR DESCRIPTION
Updates to `opinf.lstsq`:

- New `TruncatedSVDSolver` class.
- `predict()` has been renamed `solve()` for `opinf.lstsq` solver classes to not clash with `predict()` from `opinf.roms` / `opinf.models` classes.
- `solve()` always returns a two-dimensional array, even if $r = 1$.

Various small improvements to tests and documentation.