### PR TITLE
ShiftScaleTransformer Scaling Options "maxnorm" and "maxnormsym"

### DIFF
--- a/docs/source/api/pre.ipynb
+++ b/docs/source/api/pre.ipynb
@@ -60,7 +60,7 @@
     "::::{admonition} Example Data\n",
     ":class: tip\n",
     "\n",
-    "The examples on this page use data from the combustion problem described in {cite}`swischuk2020combustion`.\n",
+    "The examples on this page use data downsampled from the combustion problem described in {cite}`swischuk2020combustion`.\n",
     "\n",
     ":::{dropdown} State Variables\n",
     "\n",
@@ -73,8 +73,8 @@
     "- Specific volume (inverse density) $\\xi = 1/\\rho$\n",
     "- Chemical species molar concentrations for CH$_{4}$, O$_{2}$, CO$_{2}$, and H$_{2}$O.\n",
     "\n",
-    "The dimension of the spatial discretization in the full example in {cite}`swischuk2020combustion` is $38{,}523$ per variable, so $n = 9 \\times 38{,}523 = 346{,}707$.\n",
-    "Here we have downsampled the state dimension to $535$ for each variable for demonstration purposes, i.e., $n = 9 \\times 535 = 4{,}815$.\n",
+    "The dimension of the spatial discretization in the full example in {cite}`swischuk2020combustion` is $n_x = 38{,}523$ for each of the $n_q = 9$ variables, so the total state dimension is $n_q n_x = 9 \\times 38{,}523 = 346{,}707$.\n",
+    "For demonstration purposes, we have downsampled the state dimension to $n_x' = 535$, hence $n = n_q n_x' = 9 \\times 535 = 4{,}815$ is the total state dimension of the example data.\n",
     ":::\n",
     "\n",
     "You can [download the data here](https://github.com/Willcox-Research-Group/rom-operator-inference-Python3/raw/data/pre_example.npy) to repeat the experiments.\n",
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,6 +137,57 @@
     "A [lifting map](opinf.lift) can be viewed as a type of preprocessing map, $\\mathcal{L}:\\RR^{n_1}\\to\\RR^{n_2}$.\n",
     "However, the preprocessing transformations defined in this module map from a vector space back to itself ($n_1 = n_2$) while lifting maps may augment the state with additional variables ($n_2 \\ge n_1$).\n",
     ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "::::{admonition} Fit-and-Transform versus Transform\n",
+    ":class: important\n",
+    "\n",
+    "Pre-processing transformation classes are calibrated through user-provided hyperparameters in the constructor and/or training snapshots passed to ``fit()`` or ``fit_transform()``.\n",
+    "The ``transform()`` method applies but *does not alter* the transformation.\n",
+    "Some transformations are designed so that the transformed training data has certain properties, but those properties are not guaranteed to hold for transformed data that was not used for training.\n",
+    "\n",
+    ":::{dropdown} Example\n",
+    "\n",
+    "Consider a set of training snapshots $\\{\\q_{j}\\}_{j=0}^{k-1}\\subset\\RR^n$.\n",
+    "The {class}`ShiftScaleTransformer` can shift data by the mean training snapshot, meaning it can represent the transformation $\\mathcal{T}:\\RR^{n}\\to\\RR^{n}$ given by\n",
+    "\n",
+    "$$\n",
+    "\\begin{aligned}\n",
+    "    \\mathcal{T}(\\q) = \\q - \\bar{\\q},\n",
+    "    \\qquad\n",
+    "    \\bar{\\q} = \\frac{1}{k}\\sum_{j=0}^{k-1}\\q_{j}.\n",
+    "\\end{aligned}\n",
+    "$$\n",
+    "\n",
+    "The key property of this transformation is that the transformed training snapshots have zero mean.\n",
+    "That is,\n",
+    "\n",
+    "$$\n",
+    "\\begin{aligned}\n",
+    "    \\frac{1}{k}\\sum_{j=0}^{k-1}\\mathcal{T}(\\q_j)\n",
+    "    = \\frac{1}{k}\\sum_{j=0}^{k-1}(\\q_j - \\bar{\\q})\n",
+    "    = \\frac{1}{k}\\sum_{j=0}^{k-1}\\q_j - \\frac{1}{k}\\sum_{j=0}^{k-1}\\bar{\\q}\n",
+    "    = \\bar{\\q} - \\frac{k}{k}\\bar{\\q}\n",
+    "    = \\0.\n",
+    "\\end{aligned}\n",
+    "$$\n",
+    "\n",
+    "However, for any other collection $\\{\\mathbf{x}_j\\}_{j=0}^{k'-1}\\subset\\RR^{n}$ of snapshots, the set of transformed snapshots $\\{\\mathcal{T}(\\mathbf{x}_j)\\}_{j=0}^{k'-1}$ is not guaranteed to have zero mean because $\\mathcal{T}$ shifts by the mean of the $\\q_j$'s, not the mean of the $\\mathbf{x}_j$'s.\n",
+    "That is,\n",
+    "\n",
+    "$$\n",
+    "\\begin{aligned}\n",
+    "    \\frac{1}{k'}\\sum_{j=0}^{k'-1}\\mathcal{T}(\\mathbf{x}_j)\n",
+    "    = \\frac{1}{k'}\\sum_{j=0}^{k'-1}(\\mathbf{x}_j - \\bar{\\q})\n",
+    "    \\neq \\0.\n",
+    "\\end{aligned}\n",
+    "$$\n",
+    ":::\n",
+    "::::"
    ]
   },
   {
@@ -214,7 +265,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The most common type of shift sets the reference snapshot to be the average of the training snapshots:\n",
+    "One strategy that is often effective for Operator Inference is to set the reference snapshot to be the average of the training snapshots:\n",
     "\n",
     "$$\n",
     "    \\bar{\\q}\n",
@@ -352,7 +403,7 @@
    "metadata": {},
    "source": [
     "Many engineering problems feature multiple variables with ranges across different scales.\n",
-    "For such cases, it is often beneficial to scale the variables to similar ranges so that one variable does not overwhelm the other in the operator learning.\n",
+    "For such cases, it is often beneficial to scale the variables to similar ranges so that one variable does not overwhelm the other during operator learning.\n",
     "In other words, training data should be nondimensionalized when possible.\n",
     "\n",
     "A scaling operation for a single variable is given by\n",
@@ -362,7 +413,7 @@
     "$$\n",
     "\n",
     "where $\\alpha \\neq 0$ and $\\q'$ is a training snapshot after shifting (when desired).\n",
-    "The :class:`ScaleTransformer` class receives a scaler $\\alpha$ and implements this transformation."
+    "The {class}`ScaleTransformer` class receives a scaler $\\alpha$ and implements this transformation."
    ]
   },
   {
@@ -668,7 +719,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -738,7 +789,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -806,7 +857,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -832,7 +883,7 @@
     ":class: note\n",
     "\n",
     "- In this example, the `state_dimension` could be set in the constructor because the `w` argument is a vector of length $n$. However, the `state_dimension` is not required to be set until [`fit_transform()`](TransformerTemplate.fit_transform).\n",
-    "- Because the transformation is dictated by the choice of `\\w` and not calibrated from data, [`fit_transform()`](TransformerTemplate.fit_transform) simply calls [`transform()`](TransformerTemplate.transform).\n",
+    "- Because the transformation is dictated by the choice of `w` and not calibrated from data, [`fit_transform()`](TransformerTemplate.fit_transform) simply calls [`transform()`](TransformerTemplate.transform).\n",
     "- When `locs` is provided in [`inverse_transform()`](TransformerTemplate.inverse_transform), it is assumed that the `states_transformed` are the elements of the state vector at the given locations. That is,`inverse_transform(transform(states)[locs], locs) == states[locs]`.\n",
     ":::"
    ]

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -8,7 +8,7 @@
 [![PyPI](https://img.shields.io/pypi/wheel/opinf)](https://pypi.org/project/opinf/)
 
 :::{attention}
-This documentation is for `opinf` version `0.5`, which introduced major changes from the previous version `0.4.5`.
+This documentation is for `opinf` version `0.5.x`, which introduced major changes from the previous version `0.4.5`.
 See updates and notes for old versions [here](./opinf/changelog.md).
 :::
 

--- a/docs/source/opinf/changelog.md
+++ b/docs/source/opinf/changelog.md
@@ -5,6 +5,11 @@
 New versions may introduce substantial new features or API adjustments.
 :::
 
+## Version 0.5.11
+
+- New scaling option for ``pre.ShiftScaleTransformer`` so that training snapshots have at maximum norm 1. Contributed by [@nicolearetz](https://github.com/nicolearetz).
+- Small clarifications to ``pre.ShiftScaleTransformer`` and updates to the ``pre`` documentation.
+
 ## Version 0.5.10
 
 New POD basis solver option `basis.PODBasis(solver="method-of-snapshots")` (or `solver="eigh"`), which solves a symmetric eigenvalue problem instead of computing a (weighted) SVD. This method is more efficient than the SVD for snapshot matrices $\mathbf{Q}\in\mathbb{R}^{n\times k}$ where $n \gg k$ and is significantly more efficient than the SVD when a non-diagonal weight matrix is provided.

--- a/src/opinf/__init__.py
+++ b/src/opinf/__init__.py
@@ -7,7 +7,7 @@ GitHub:
     https://github.com/Willcox-Research-Group/rom-operator-inference-Python3
 """
 
-__version__ = "0.5.10"
+__version__ = "0.5.11"
 
 from . import (
     basis,

--- a/src/opinf/pre/__init__.py
+++ b/src/opinf/pre/__init__.py
@@ -1,5 +1,7 @@
 # pre/__init__.py
-"""Tools for preprocessing snapshot data prior to compression."""
+"""Tools for preprocessing snapshot data after (optional) lifting but prior to
+compression.
+"""
 
 from ._base import *
 from ._multi import *

--- a/src/opinf/pre/_shiftscale.py
+++ b/src/opinf/pre/_shiftscale.py
@@ -778,7 +778,7 @@ class ShiftScaleTransformer(TransformerTemplate):
                 - .. math:: \Q'' = \frac{1}{\max_j(\|\Q'_{:,j}\|_2)}\Q'
               * - ``byrow=False``
                 - :math:`\mean(\Q'')=\frac{\mean(\Q')}{\max_j(\|\Q'_{:,j}\|)}`
-                  and :math:`\max(\|\Q''_{:,j}\|) = 1`
+                  and :math:`\max_j(\|\Q''_{:,j}\|) = 1`
               * - ``byrow=True``
                 - ``ValueError``: use ``'maxabs'`` instead
 
@@ -793,7 +793,7 @@ class ShiftScaleTransformer(TransformerTemplate):
                      \Q'' = \frac{\Q' - \text{mean}(\Q')}{
                      \max_j(\|\Q'_{:,j} - \text{mean}(\Q')\|_2)}
               * - ``byrow=False``
-                - :math:`\mean(\Q'')=0` and :math:`\max(\|\Q''_{:,j}\|) = 1`
+                - :math:`\mean(\Q'')=0` and :math:`\max_j(\|\Q''_{:,j}\|) = 1`
               * - ``byrow=True``
                 - ``ValueError``: use ``'maxabssym'`` instead
 

--- a/tests/pre/test_shiftscale.py
+++ b/tests/pre/test_shiftscale.py
@@ -7,7 +7,10 @@ import numpy as np
 
 import opinf
 
-from test_base import _TestTransformer
+try:
+    from .test_base import _TestTransformer
+except ImportError:
+    from test_base import _TestTransformer
 
 
 # Functions ===================================================================
@@ -421,11 +424,15 @@ class TestShiftScaleTransformer(_TestTransformer):
             assert np.allclose(np.max(np.abs(Y), axis=1), 1)
 
             # Test norm scaling.
-            st = self.Transformer(
-                centering=centering, scaling="maxnorm", byrow=True
+            with pytest.raises(ValueError) as ex:
+                self.Transformer(
+                    centering=centering,
+                    scaling="maxnorm",
+                    byrow=True,
+                )
+            assert ex.value.args[0] == (
+                "scaling 'maxnorm' is invalid when byrow=True"
             )
-            with pytest.raises(RuntimeError):
-                fit_transform_copy(st, X)
 
     def test_mains(self, n=11, k=21):
         """Test fit(), fit_transform(), transform(), transform_ddts(), and


### PR DESCRIPTION
option "maxnorm" for transformers.
Snapshots are transformed such that the maximum Euclidean norm of the transformed snapshots (with or without centering) is at most 1. This is useful because the norm of the Kronecker product of two vectors is equal to the product of the two vectors' norms: $\|x \otimes y\| = \|x\| \|y\|$. Scaling the snapshots to have maximum norm 1 guarantees that the entries of the OpInf data matrix remain bounded even for high-dimensional polynomial operators. 