### PR TITLE
Regselect: catch errors in refit()

### DIFF
--- a/.github/workflows/test_src.yml
+++ b/.github/workflows/test_src.yml
@@ -26,6 +26,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/docs/literature.bib
+++ b/docs/literature.bib
@@ -656,3 +656,13 @@
     doi = {10.48550/arXiv.2502.10888},
     category = {structure}
 }
+
+@article{kang2025semiconductor,
+    title = {Parametric {O}perator {I}nference to simulate the purging process in semiconductor manufacturing},
+    author = {Seunghyon Kang and Hyeonghun Kim and Boris Kramer},
+    journal = {arXiv},
+    volume = {2504.03990},
+    year = {2025},
+    doi = {10.48550/arXiv.2504.03990},
+    category = {application}
+}

--- a/docs/source/opinf/changelog.md
+++ b/docs/source/opinf/changelog.md
@@ -5,6 +5,13 @@
 New versions may introduce substantial new features or API adjustments.
 :::
 
+## Version 0.5.14
+
+- Catch any errors in `fit_regselect*()` that occur when the model uses `refit()`.
+- Tikhonov-type least-squares solvers do not require the regularizer in the constructor but will raise an `AttributeError` in `solve()` (and other methods) if the regularizer is not set. This makes using `fit_regselect_*()` much less cumbersome.
+- `PODBasis.fit(Q)` raises a warning when using the `"method-of-snapshots"`/`"eigh"` strategy if $n < k$ for $\mathbf{Q}\in\mathbb{R}^{n \times k}.$ In this case, calculating the $n \times k$ SVD is likely more efficient than the $k \times k$ eigenvalue problem.
+- Added Python 3.13 to list of tests.
+
 ## Version 0.5.13
 
 Bayesian operator inference:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,13 +39,13 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "bibtexparser>=2.0.0b7",
-    "tox>=4",
-    "pre-commit>=3.7.1",
-    "flake8==7.0.0",
     "black==24.4.2",
+    "flake8==7.0.0",
     "jupyterlab",
-    "pandas",
     "notebook",
+    "pandas",
+    "pre-commit>=3.7.1",
+    "tox>=4",
 ]
 
 [project.urls]

--- a/src/opinf/__init__.py
+++ b/src/opinf/__init__.py
@@ -7,7 +7,7 @@ GitHub:
     https://github.com/Willcox-Research-Group/rom-operator-inference-Python3
 """
 
-__version__ = "0.5.13"
+__version__ = "0.5.14"
 
 from . import (
     basis,

--- a/src/opinf/roms/_base.py
+++ b/src/opinf/roms/_base.py
@@ -651,14 +651,26 @@ class _BaseROM(abc.ABC):
         )
 
         # Fit the model for the first time.
-        states = self._fit_and_return_training_data(
-            parameters=parameters,
-            states=states,
-            lhs=ddts,
-            inputs=inputs,
-            fit_transformer=fit_transformer,
-            fit_basis=fit_basis,
-        )
+        initialized = False
+        for reg in candidates:
+            self.model.solver.regularizer = regularizer_factory(reg)
+            try:
+                states = self._fit_and_return_training_data(
+                    parameters=parameters,
+                    states=states,
+                    lhs=ddts,
+                    inputs=inputs,
+                    fit_transformer=fit_transformer,
+                    fit_basis=fit_basis,
+                )
+                initialized = True
+                break
+            except Exception:  # pragma: no cover
+                pass
+        if not initialized:  # pragma: no cover
+            raise RuntimeError(
+                "fit() failed with all regularization candidates"
+            )
 
         # Set up the regularization selection.
         shifts, limits = self._get_stability_limits(states, stability_margin)
@@ -868,14 +880,26 @@ class _BaseROM(abc.ABC):
         )
 
         # Fit the model for the first time.
-        states = self._fit_and_return_training_data(
-            parameters=parameters,
-            states=states,
-            lhs=None,
-            inputs=inputs,
-            fit_transformer=fit_transformer,
-            fit_basis=fit_basis,
-        )
+        initialized = False
+        for reg in candidates:
+            self.model.solver.regularizer = regularizer_factory(candidates[0])
+            try:
+                states = self._fit_and_return_training_data(
+                    parameters=parameters,
+                    states=states,
+                    lhs=None,
+                    inputs=inputs,
+                    fit_transformer=fit_transformer,
+                    fit_basis=fit_basis,
+                )
+                initialized = True
+                break
+            except Exception:  # pragma: no cover
+                pass
+        if not initialized:  # pragma: no cover
+            raise RuntimeError(
+                "fit() failed with all regularization candidates"
+            )
 
         # Set up the regularization selection.
         shifts, limits = self._get_stability_limits(states, stability_margin)

--- a/src/opinf/roms/_base.py
+++ b/src/opinf/roms/_base.py
@@ -699,7 +699,12 @@ class _BaseROM(abc.ABC):
             candidate by solving the model, checking for stability, and
             comparing to available training data.
             """
-            update_model(reg_params)
+            try:
+                update_model(reg_params)
+            except Exception as ex:
+                if verbose:
+                    print(f"{type(ex).__name__} in refit(): {ex}")
+                return np.inf
 
             # Pass stability checks.
             for tcase in processed_test_cases:
@@ -902,7 +907,12 @@ class _BaseROM(abc.ABC):
             candidate by solving the model, checking for stability, and
             comparing to available training data.
             """
-            update_model(reg_params)
+            try:
+                update_model(reg_params)
+            except Exception as ex:
+                if verbose:
+                    print(f"{type(ex).__name__} in refit(): {ex}")
+                return np.inf
 
             # Pass stability checks.
             for tcase in processed_test_cases:

--- a/tests/basis/test_pod.py
+++ b/tests/basis/test_pod.py
@@ -358,6 +358,15 @@ class TestPODBasis:
             np.eye(r),
         )
 
+        Q = np.random.random((n, 2 * n))
+        with pytest.warns(opinf.errors.OpInfWarning) as wn:
+            basis.fit(Q)
+        assert len(wn) == 1
+        assert wn[0].message.args[0] == (
+            "state dimension < number of states, "
+            "method-of-snapshots / eigh may be inefficient"
+        )
+
     # Visualization -----------------------------------------------------------
     def test_plots(self, n=40, r=4):
         """Lightly test plot_*()."""

--- a/tests/lstsq/test_tikhonov.py
+++ b/tests/lstsq/test_tikhonov.py
@@ -71,6 +71,10 @@ class TestL2Solver(_TestBaseRegularizedSolver):
     # Properties --------------------------------------------------------------
     def test_regularizer(self):
         """Test regularizer property and setter."""
+        solver = self.Solver()
+        assert solver.regularizer is None
+        str(solver)
+
         # Try with nonscalar regularizer.
         with pytest.raises(TypeError) as ex:
             self.Solver([1, 2, 3])
@@ -99,6 +103,11 @@ class TestL2Solver(_TestBaseRegularizedSolver):
                 o1 = o1.reshape((1, -1))
             assert o2.shape == o1.shape
             assert np.allclose(o2, o1)
+
+        solver = self.Solver().fit(D, Z)
+        with pytest.raises(AttributeError) as ex:
+            solver.solve()
+        assert ex.value.args[0] == "solver regularizer not set"
 
         for solver in self.get_solvers():
 
@@ -162,6 +171,12 @@ class TestL2Solver(_TestBaseRegularizedSolver):
             regcond_true = np.linalg.cond(np.vstack((A, reg * np.eye(d))))
             _singletest(reg, regcond_true)
 
+        # No regularizer.
+        solver = self.Solver().fit(A, B)
+        with pytest.raises(AttributeError) as ex:
+            solver.regcond()
+        assert ex.value.args[0] == "solver regularizer not set"
+
     def test_regresidual(self, k=20, d=11, r=3, ntests=5):
         """Test regresidual()."""
         solver = self.Solver(0)
@@ -207,6 +222,12 @@ class TestL2Solver(_TestBaseRegularizedSolver):
             ans = np.linalg.norm(A @ x - b) ** 2 + np.linalg.norm(reg * x) ** 2
             assert np.isclose(residual[0], ans)
 
+        # No regularizer.
+        solver = self.Solver().fit(A, B)
+        with pytest.raises(AttributeError) as ex:
+            solver.regresidual(None)
+        assert ex.value.args[0] == "solver regularizer not set"
+
 
 class TestL2DecoupledSolver(_TestBaseRegularizedSolver):
     """Test lstsq._tikhonov.L2DecoupledSolver."""
@@ -222,6 +243,10 @@ class TestL2DecoupledSolver(_TestBaseRegularizedSolver):
     # Properties --------------------------------------------------------------
     def test_regularizer(self, k=10, d=6, r=3):
         """Test _check_regularizer_shape(), fit(), and regularizer property."""
+        solver = self.Solver()
+        assert solver.regularizer is None
+        str(solver)
+
         solver = self.Solver(np.random.random(r + 1))
         A = np.empty((k, d))
         B = np.empty((r, k))
@@ -259,6 +284,12 @@ class TestL2DecoupledSolver(_TestBaseRegularizedSolver):
         Z = np.random.random((r, k))
         Id = np.eye(d)
         ZpadT = np.vstack((Z.T, np.zeros((d, r))))
+
+        solver = self.Solver()
+        solver.fit(D, Z)
+        with pytest.raises(AttributeError) as ex:
+            solver.solve()
+        assert ex.value.args[0] == "solver regularizer not set"
 
         for solver in self.get_solvers():
             Ohat1 = []
@@ -316,6 +347,12 @@ class TestL2DecoupledSolver(_TestBaseRegularizedSolver):
         conds = [np.linalg.cond(np.vstack((A, reg * Id))) for reg in regs]
         assert np.allclose(solver.regcond(), conds)
 
+        # No regularizer.
+        solver = self.Solver().fit(A, B)
+        with pytest.raises(AttributeError) as ex:
+            solver.regcond()
+        assert ex.value.args[0] == "solver regularizer not set"
+
     def test_regresidual(self, k=20, d=11, r=3):
         """Test lstsq._tikhonov.L2DecoupledSolver.residual()."""
         solver = self.Solver([0] * r)
@@ -350,6 +387,12 @@ class TestL2DecoupledSolver(_TestBaseRegularizedSolver):
         )
         assert np.allclose(residual, ans)
 
+        # No regularizer.
+        solver = self.Solver().fit(A, B)
+        with pytest.raises(AttributeError) as ex:
+            solver.regresidual(None)
+        assert ex.value.args[0] == "solver regularizer not set"
+
     def test_save_load_and_copy_via_verify(self, k=20, d=11):
         return super().test_save_load_and_copy_via_verify(k, d, 4)
 
@@ -371,6 +414,10 @@ class TestTikhonovSolver(_TestBaseRegularizedSolver):
     # Properties --------------------------------------------------------------
     def test_regularizer(self, k=20, d=11, r=3):
         """Test _check_regularizer_shape(), regularizer, and method."""
+        solver = self.Solver()
+        assert solver.regularizer is None
+        str(solver)
+
         Z = np.random.random((d, d))
 
         with pytest.raises(ValueError) as ex:
@@ -492,6 +539,12 @@ class TestTikhonovSolver(_TestBaseRegularizedSolver):
         d = 10
         A = np.random.random((k, d))
         B = np.random.random((r, k))
+
+        solver = self.Solver().fit(A, B)
+        with pytest.raises(AttributeError) as ex:
+            solver.solve()
+        assert ex.value.args[0] == "solver regularizer not set"
+
         Bpad = np.concatenate((B.T, np.zeros((d, r))))
         b = B[0, :]
         bpad = Bpad[:, 0]
@@ -595,6 +648,12 @@ class TestTikhonovSolver(_TestBaseRegularizedSolver):
             solver.regularizer = P
             assert np.isclose(solver.regcond(), cond)
 
+        # No regularizer.
+        solver = self.Solver().fit(A, B)
+        with pytest.raises(AttributeError) as ex:
+            solver.regcond()
+        assert ex.value.args[0] == "solver regularizer not set"
+
     def test_regresidual(self, k=20, d=11, r=3, ntests=5):
         """Test lstsq._tikhonov.TikhonovSolver.residual()."""
         Z = np.zeros(d)
@@ -635,6 +694,12 @@ class TestTikhonovSolver(_TestBaseRegularizedSolver):
             ans = np.linalg.norm(A @ x - b) ** 2 + np.linalg.norm(P * x) ** 2
             assert np.isclose(residual[0], ans)
 
+        # No regularizer.
+        solver = self.Solver().fit(A, B)
+        with pytest.raises(AttributeError) as ex:
+            solver.regresidual(None)
+        assert ex.value.args[0] == "solver regularizer not set"
+
     def test_save_load_and_copy_via_verify(self, k=20, r=6):
         return super().test_save_load_and_copy_via_verify(k=k, d=10, r=r)
 
@@ -655,6 +720,10 @@ class TestTikhonovDecoupledSolver(_TestBaseRegularizedSolver):
     # Properties --------------------------------------------------------------
     def test_regularizer(self, k=10, d=6, r=3):
         """Test _check_regularizer_shape() and regularizer."""
+        solver = self.Solver()
+        assert solver.regularizer is None
+        str(solver)
+
         Z = np.random.random((d, d))
         solver = opinf.lstsq.TikhonovDecoupledSolver([Z] * r)
         A = np.empty((k, d))
@@ -699,9 +768,14 @@ class TestTikhonovDecoupledSolver(_TestBaseRegularizedSolver):
         r = len(Ps)
         A = np.random.random((k, d))
         B = np.random.random((r, k))
-        solver = self.Solver(Ps)
+
+        solver = self.Solver().fit(A, B)
+        with pytest.raises(AttributeError) as ex:
+            solver.solve()
+        assert ex.value.args[0] == "solver regularizer not set"
 
         # Try solving before fitting.
+        solver = self.Solver(Ps)
         with pytest.raises(AttributeError) as ex:
             solver.solve()
         assert ex.value.args[0] == "solver not trained, call fit()"
@@ -772,6 +846,12 @@ class TestTikhonovDecoupledSolver(_TestBaseRegularizedSolver):
         conds = [np.linalg.cond(np.vstack((A, P))) for P in Ps]
         assert np.allclose(solver.regcond(), conds)
 
+        # No regularizer.
+        solver = self.Solver().fit(A, B)
+        with pytest.raises(AttributeError) as ex:
+            solver.regcond()
+        assert ex.value.args[0] == "solver regularizer not set"
+
     def test_residual(self, k=20):
         return super().test_residual(k, d=10, r=5)
 
@@ -792,6 +872,12 @@ class TestTikhonovDecoupledSolver(_TestBaseRegularizedSolver):
             [la.norm(P @ Ohat[i], ord=2) ** 2 for i, P in enumerate(Ps)]
         )
         assert np.allclose(residual, ans)
+
+        # No regularizer.
+        solver = self.Solver().fit(A, B)
+        with pytest.raises(AttributeError) as ex:
+            solver.regresidual(None)
+        assert ex.value.args[0] == "solver regularizer not set"
 
     def test_save_load_and_copy_via_verify(self, k=20):
         return super().test_save_load_and_copy_via_verify(k=k, d=10, r=5)

--- a/tests/utils/test_timer.py
+++ b/tests/utils/test_timer.py
@@ -42,6 +42,11 @@ class TestTimedBlock:
             pass
         assert obj.message == message
 
+        # No message.
+        with self.Timer(None) as obj:
+            pass
+        assert obj.message == ""
+
     @skipwindows
     def test_timeout(self, message="TimedBlock test with problems"):
         # Time limit expires.

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox>=4
-env_list = py{39,310,311,312}
+env_list = py{39,310,311,312,313}
 
 [testenv]
 description = Run unit tests with pytest


### PR DESCRIPTION
- Catch any errors in `fit_regselect*()` that occur when the model uses `refit()`.
- Tikhonov-type least-squares solvers do not require the regularizer in the constructor but will raise an `AttributeError` in `solve()` (and other methods) if the regularizer is not set. This makes using `fit_regselect_*()` much less cumbersome.
- `PODBasis.fit(Q)` raises a warning when using the `"method-of-snapshots"`/`"eigh"` strategy if $n < k$ for $\mathbf{Q}\in\mathbb{R}^{n \times k}.$ In this case, calculating the $n \times k$ SVD is likely more efficient than the $k \times k$ eigenvalue problem.
- Added Python 3.13 to list of tests.
- Added one reference to the literature page.

Version update `0.5.13` --> `0.5.14`.