### PR TITLE
Regselect: accept solver without explicitly setting regularization beforehand

### DIFF
--- a/docs/source/opinf/changelog.md
+++ b/docs/source/opinf/changelog.md
@@ -7,9 +7,9 @@ New versions may introduce substantial new features or API adjustments.
 
 ## Version 0.5.15
 
-- Improvement to `fit_regselect_*()` so that the regularization does not have to be initialized before fitting the model.
+- Improvement to `fit_regselect_*()` so that the regularization does not have to be initialized before fitting the model. This fixes a longstanding chicken/egg problem and makes using `fit_regselect_*()` much less cumbersome.
+- Ensured error computation correctly aligns training and predicted states in  `fit_regselect_continuous()`. Previously, this could have been misaligned when using a time derivative estimator that truncates states.
 - Time derivative estimators in `opinf.ddt` now have a `mask()` method that map states to the estimation grid.
-- Applied the `mask()` in `fit_regselect_continuous()` so that the error computation is correctly aligned with the training snapshots.
 - Added regression tests based on the tutorial notebooks.
 - Added `pytest` and `pytest-cov` to the dependencies for developers.
 

--- a/docs/source/opinf/changelog.md
+++ b/docs/source/opinf/changelog.md
@@ -5,10 +5,18 @@
 New versions may introduce substantial new features or API adjustments.
 :::
 
+## Version 0.5.15
+
+- Improvement to `fit_regselect_*()` so that the regularization does not have to be initialized before fitting the model.
+- Time derivative estimators in `opinf.ddt` now have a `mask()` method that map states to the estimation grid.
+- Applied the `mask()` in `fit_regselect_continuous()` so that the error computation is correctly aligned with the training snapshots.
+- Added regression tests based on the tutorial notebooks.
+- Added `pytest` and `pytest-cov` to the dependencies for developers.
+
 ## Version 0.5.14
 
 - Catch any errors in `fit_regselect*()` that occur when the model uses `refit()`.
-- Tikhonov-type least-squares solvers do not require the regularizer in the constructor but will raise an `AttributeError` in `solve()` (and other methods) if the regularizer is not set. This makes using `fit_regselect_*()` much less cumbersome.
+- Tikhonov-type least-squares solvers do not require the regularizer in the constructor but will raise an `AttributeError` in `solve()` (and other methods) if the regularizer is not set.
 - `PODBasis.fit(Q)` raises a warning when using the `"method-of-snapshots"`/`"eigh"` strategy if $n < k$ for $\mathbf{Q}\in\mathbb{R}^{n \times k}.$ In this case, calculating the $n \times k$ SVD is likely more efficient than the $k \times k$ eigenvalue problem.
 - Added Python 3.13 to list of tests.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ dev = [
     "notebook",
     "pandas",
     "pre-commit>=3.7.1",
+    "pytest",
+    "pytest-cov",
     "tox>=4",
 ]
 

--- a/src/opinf/__init__.py
+++ b/src/opinf/__init__.py
@@ -7,7 +7,7 @@ GitHub:
     https://github.com/Willcox-Research-Group/rom-operator-inference-Python3
 """
 
-__version__ = "0.5.14"
+__version__ = "0.5.15"
 
 from . import (
     basis,

--- a/src/opinf/ddt/_base.py
+++ b/src/opinf/ddt/_base.py
@@ -104,7 +104,7 @@ class DerivativeEstimatorTemplate(abc.ABC):
             raise errors.DimensionalityError("states must be two-dimensional")
         if check_against_time and states.shape[-1] != self.time_domain.size:
             raise errors.DimensionalityError(
-                "states not aligned with time_domain"
+                "states and time_domain not aligned"
             )
         if inputs is not None:
             if inputs.ndim == 1:
@@ -135,6 +135,40 @@ class DerivativeEstimatorTemplate(abc.ABC):
         _inputs : (m, k') ndarray or None
             Inputs corresponding to ``_states``, if applicable.
             **Only returned** if ``inputs`` is provided.
+
+        Raises
+        ------
+        opinf.errors.DimensionalityError
+            If the ``states`` or ``inputs`` are not aligned with the
+            :attr:`time_domain`.
+        """
+        raise NotImplementedError  # pragma: no cover
+
+    @abc.abstractmethod
+    def mask(self, states):
+        """Extract the states that align with estimated time derivatives.
+
+        This method is used in post-hoc regularization selection routines.
+
+        Parameters
+        ----------
+        states : (r, k) ndarray
+            State snapshots, either full or (preferably) reduced.
+
+        Returns
+        -------
+        _states : (r, k') ndarray
+            Subset of the state snapshots.
+
+        Examples
+        --------
+        >>> Q, dQ = estimator.esimate(states)
+        >>> Q2 = estimator.mask(states)
+        >>> np.all(Q2 == Q)
+        True
+        >>> Q3 = estimator.mask(other_states_on_same_time_grid)
+        >>> Q3.shape == Q.shape
+        True
         """
         raise NotImplementedError  # pragma: no cover
 

--- a/src/opinf/ddt/_base.py
+++ b/src/opinf/ddt/_base.py
@@ -145,20 +145,21 @@ class DerivativeEstimatorTemplate(abc.ABC):
         raise NotImplementedError  # pragma: no cover
 
     @abc.abstractmethod
-    def mask(self, states):
-        """Extract the states that align with estimated time derivatives.
+    def mask(self, arr):
+        """Map an array from the training time domain to the domain of the
+        estimated time derivatives.
 
         This method is used in post-hoc regularization selection routines.
 
         Parameters
         ----------
-        states : (r, k) ndarray
-            State snapshots, either full or (preferably) reduced.
+        arr : (..., k) ndarray
+            Array (states, inputs, etc.) aligned with the training time domain.
 
         Returns
         -------
-        _states : (r, k') ndarray
-            Subset of the state snapshots.
+        _arr : (..., k') ndarray
+            Array mapped to the domain of the estimated time derivatives.
 
         Examples
         --------

--- a/src/opinf/ddt/_finite_difference.py
+++ b/src/opinf/ddt/_finite_difference.py
@@ -774,9 +774,8 @@ class UniformFiniteDifferencer(DerivativeEstimatorTemplate):
         Time domain corresponding to the snapshot data.
         This class requires uniformly spaced time domains, see
         :class:`NonuniformFiniteDifferencer` for non-uniform domains.
-    scheme : str or callable
-        Finite difference scheme to use.
-        **Options:**
+    scheme : str
+        Finite difference scheme to use. **Options:**
 
         * ``'fwd1'``: first-order forward differences, see :func:`fwd1`.
         * ``'fwd2'``: second-order forward differences, see :func:`fwd2`.
@@ -796,17 +795,6 @@ class UniformFiniteDifferencer(DerivativeEstimatorTemplate):
         * ``'ord2'``: second-order differences, see :func:`ord2`.
         * ``'ord4'``: fourth-order differences, see :func:`ord4`.
         * ``'ord6'``: sixth-order differences, see :func:`ord6`.
-
-        If ``scheme`` is a callable function, its signature must match the
-        following syntax.
-
-        .. code-block:: python
-
-           _states, ddts = scheme(states, dt)
-           _states, ddts, _inputs = scheme(states, dt, inputs)
-
-        Here ``dt`` is a positive float, the uniform time step.
-        Each output should have the same number of columns.
     """
 
     _schemes = types.MappingProxyType(
@@ -832,7 +820,7 @@ class UniformFiniteDifferencer(DerivativeEstimatorTemplate):
         }
     )
 
-    def __init__(self, time_domain, scheme="ord4"):
+    def __init__(self, time_domain, scheme: str = "ord4"):
         """Store the time domain and set the finite difference scheme."""
         DerivativeEstimatorTemplate.__init__(self, time_domain)
 
@@ -842,13 +830,9 @@ class UniformFiniteDifferencer(DerivativeEstimatorTemplate):
             raise ValueError("time domain must be uniformly spaced")
 
         # Set the finite difference scheme.
-        if not callable(scheme):
-            if scheme not in self._schemes:
-                raise ValueError(
-                    f"invalid finite difference scheme '{scheme}'"
-                )
-            scheme = self._schemes[scheme]
-        self.__scheme = scheme
+        if scheme not in self._schemes:
+            raise ValueError(f"invalid finite difference scheme '{scheme}'")
+        self.__scheme = self._schemes[scheme]
 
     # Properties --------------------------------------------------------------
     @property
@@ -898,6 +882,48 @@ class UniformFiniteDifferencer(DerivativeEstimatorTemplate):
         """
         states, inputs = self._check_dimensions(states, inputs, False)
         return self.scheme(states, self.dt, inputs)
+
+    def mask(self, states):
+        """Extract the states that align with estimated time derivatives.
+        Since :meth:`estimate` provides an estimate at every time step, this
+        method simply returns ``states``.
+
+        This method is used in post-hoc regularization selection routines.
+
+        Parameters
+        ----------
+        states : (r, k) ndarray
+            State snapshots, either full or (preferably) reduced.
+
+        Returns
+        -------
+        _states : (r, k') ndarray
+            Subset of the state snapshots.
+
+        Examples
+        --------
+        >>> Q, dQ = estimator.esimate(states)
+        >>> Q2 = estimator.mask(states)
+        >>> np.all(Q2 == Q)
+        True
+        >>> Q3 = estimator.mask(other_states_on_same_time_grid)
+        >>> Q3.shape == Q.shape
+        True
+        """
+        schema = self.scheme.__name__
+        mode, order = schema[:3], int(schema[3])
+        if mode == "ord":
+            return states
+        elif mode == "fwd":
+            cols = slice(0, -order)
+        elif mode == "bwd":
+            cols = slice(order, None)
+        elif mode == "ctr":
+            margin = order // 2
+            cols = slice(margin, -margin)
+        else:  # pragma: no cover
+            raise RuntimeError("invalid scheme name!")
+        return states[:, cols]
 
 
 class NonuniformFiniteDifferencer(DerivativeEstimatorTemplate):
@@ -966,6 +992,35 @@ class NonuniformFiniteDifferencer(DerivativeEstimatorTemplate):
         if inputs is not None:
             return states, ddts, inputs
         return states, ddts
+
+    def mask(self, states):
+        """Extract the states that align with estimated time derivatives.
+        Since :meth:`estimate` provides an estimate at every time step, this
+        method simply returns ``states``.
+
+        This method is used in post-hoc regularization selection routines.
+
+        Parameters
+        ----------
+        states : (r, k) ndarray
+            State snapshots, either full or (preferably) reduced.
+
+        Returns
+        -------
+        _states : (r, k') ndarray
+            Subset of the state snapshots.
+
+        Examples
+        --------
+        >>> Q, dQ = estimator.esimate(states)
+        >>> Q2 = estimator.mask(states)
+        >>> np.all(Q2 == Q)
+        True
+        >>> Q3 = estimator.mask(other_states_on_same_time_grid)
+        >>> Q3.shape == Q.shape
+        True
+        """
+        return states
 
 
 # Old API =====================================================================

--- a/src/opinf/ddt/_finite_difference.py
+++ b/src/opinf/ddt/_finite_difference.py
@@ -883,22 +883,21 @@ class UniformFiniteDifferencer(DerivativeEstimatorTemplate):
         states, inputs = self._check_dimensions(states, inputs, False)
         return self.scheme(states, self.dt, inputs)
 
-    def mask(self, states):
-        """Extract the states that align with estimated time derivatives.
-        Since :meth:`estimate` provides an estimate at every time step, this
-        method simply returns ``states``.
+    def mask(self, arr):
+        """Map an array from the training time domain to the domain of the
+        estimated time derivatives.
 
         This method is used in post-hoc regularization selection routines.
 
         Parameters
         ----------
-        states : (r, k) ndarray
-            State snapshots, either full or (preferably) reduced.
+        arr : (..., k) ndarray
+            Array (states, inputs, etc.) aligned with the training time domain.
 
         Returns
         -------
-        _states : (r, k') ndarray
-            Subset of the state snapshots.
+        _arr : (..., k') ndarray
+            Array mapped to the domain of the estimated time derivatives.
 
         Examples
         --------
@@ -913,7 +912,7 @@ class UniformFiniteDifferencer(DerivativeEstimatorTemplate):
         schema = self.scheme.__name__
         mode, order = schema[:3], int(schema[3])
         if mode == "ord":
-            return states
+            return arr
         elif mode == "fwd":
             cols = slice(0, -order)
         elif mode == "bwd":
@@ -923,7 +922,7 @@ class UniformFiniteDifferencer(DerivativeEstimatorTemplate):
             cols = slice(margin, -margin)
         else:  # pragma: no cover
             raise RuntimeError("invalid scheme name!")
-        return states[:, cols]
+        return arr[..., cols]
 
 
 class NonuniformFiniteDifferencer(DerivativeEstimatorTemplate):
@@ -993,22 +992,22 @@ class NonuniformFiniteDifferencer(DerivativeEstimatorTemplate):
             return states, ddts, inputs
         return states, ddts
 
-    def mask(self, states):
-        """Extract the states that align with estimated time derivatives.
-        Since :meth:`estimate` provides an estimate at every time step, this
-        method simply returns ``states``.
+    def mask(self, arr):
+        """Map an array from the training time domain to the domain of the
+        estimated time derivatives. Since this class provides an estimate at
+        every time step, this method simply returns ``arr``.
 
         This method is used in post-hoc regularization selection routines.
 
         Parameters
         ----------
-        states : (r, k) ndarray
-            State snapshots, either full or (preferably) reduced.
+        arr : (..., k) ndarray
+            Array (states, inputs, etc.) aligned with the training time domain.
 
         Returns
         -------
-        _states : (r, k') ndarray
-            Subset of the state snapshots.
+        _arr : (..., k') ndarray
+            Array mapped to the domain of the estimated time derivatives.
 
         Examples
         --------
@@ -1020,7 +1019,7 @@ class NonuniformFiniteDifferencer(DerivativeEstimatorTemplate):
         >>> Q3.shape == Q.shape
         True
         """
-        return states
+        return arr
 
 
 # Old API =====================================================================

--- a/src/opinf/ddt/_interpolation.py
+++ b/src/opinf/ddt/_interpolation.py
@@ -190,25 +190,27 @@ class InterpDerivativeEstimator(DerivativeEstimatorTemplate):
             return states, ddts
         return states, ddts, inputs
 
-    def mask(self, states):
-        """Extract the states that align with estimated time derivatives.
+    def mask(self, arr):
+        """Map an array from the training time domain to the domain of the
+        estimated time derivatives.
+
 
         This method is used in post-hoc regularization selection routines.
 
         Parameters
         ----------
-        states : (r, k) ndarray
-            State snapshots, either full or (preferably) reduced.
+        arr : (..., k) ndarray
+            Array (states, inputs, etc.) aligned with the training time domain.
 
         Returns
         -------
-        _states : (r, k') ndarray
-            Subset of the state snapshots.
+        _arr : (..., k) ndarray
+            Array mapped to the domain of the estimated time derivatives.
 
         Notes
         -----
         If :attr:`new_time_domain` is not the same as :attr:`time_domain`,
-        this method interpolates the ``states`` and evaluates the interpolant
+        this method interpolates the ``arr`` and evaluates the interpolant
         (not its derivative) over the :attr:`new_time_domain`.
 
         Examples
@@ -222,12 +224,12 @@ class InterpDerivativeEstimator(DerivativeEstimatorTemplate):
         True
         """
         if self.new_time_domain is None:
-            return states
+            return arr
 
         # Interpolate to the new time domain.
         statespline = self.InterpolatorClass(
             self.time_domain,
-            states,
+            arr,
             **self.options,
         )
         return statespline(self.new_time_domain)

--- a/src/opinf/models/mono/_nonparametric.py
+++ b/src/opinf/models/mono/_nonparametric.py
@@ -13,16 +13,16 @@ import numpy as np
 import scipy.integrate as spintegrate
 import scipy.interpolate as spinterpolate
 
-from ._base import _Model
+from ._base import _OpInfModel
 from ... import errors, utils, operators as _operators
 from ...operators import _utils as oputils
 
 
 # Base class ==================================================================
-class _NonparametricModel(_Model):
+class _NonparametricModel(_OpInfModel):
     """Base class for nonparametric monolithic models.
 
-    Parent class: :class:`opinf.models.mono._base._Model`
+    Parent class: :class:`opinf.models.mono._base._OpInfModel`
 
     Child classes:
 
@@ -249,6 +249,7 @@ class _NonparametricModel(_Model):
 
         # Execute non-intrusive learning.
         self._extract_operators(self.solver.solve())
+        return self
 
     def fit(self, states, lhs, inputs=None):
         r"""Learn the model operators from data.
@@ -311,8 +312,7 @@ class _NonparametricModel(_Model):
             return self
 
         self._fit_solver(states, lhs, inputs)
-        self.refit()
-        return self
+        return self.refit()
 
     # Model evaluation --------------------------------------------------------
     def rhs(self, state, input_=None):

--- a/src/opinf/models/mono/_parametric.py
+++ b/src/opinf/models/mono/_parametric.py
@@ -15,7 +15,7 @@ import warnings
 import numpy as np
 import scipy.interpolate as spinterpolate
 
-from ._base import _Model
+from ._base import _OpInfModel
 from ._nonparametric import (
     _FrozenDiscreteModel,
     _FrozenContinuousModel,
@@ -25,7 +25,7 @@ from ...operators import _utils as oputils
 
 
 # Base classes ================================================================
-class _ParametricModel(_Model):
+class _ParametricModel(_OpInfModel):
     """Base class for parametric monolithic models."""
 
     _ModelClass = NotImplemented  # Must be specified by child classes.
@@ -89,12 +89,12 @@ class _ParametricModel(_Model):
     @property
     def operators(self):
         """Operators comprising the terms of the model."""
-        return _Model.operators.fget(self)
+        return _OpInfModel.operators.fget(self)
 
     @operators.setter
     def operators(self, ops):
         """Set the operators."""
-        _Model.operators.fset(self, ops)
+        _OpInfModel.operators.fset(self, ops)
 
         # Check at least one operator is parametric.
         parametric_operators = [

--- a/src/opinf/roms/_base.py
+++ b/src/opinf/roms/_base.py
@@ -466,7 +466,7 @@ class _BaseROM(abc.ABC):
                 limits[ell] = np.inf
         return shifts, limits
 
-    def _fit_and_return_training_data(
+    def _fit_solver(
         self,
         parameters,
         states,
@@ -474,10 +474,10 @@ class _BaseROM(abc.ABC):
         inputs,
         fit_transformer,
         fit_basis,
-        execute_solver: bool = True,
     ):
-        """Process the training data, fit the model, and return the processed
-        training data.
+        """Process the training data and fit the model solver.
+        Returns the processed training data.
+
         """
         self._check_fit_args(lhs=lhs, inputs=inputs)
         if parameters is None:
@@ -500,9 +500,6 @@ class _BaseROM(abc.ABC):
             )
         else:
             self.model._fit_solver(parameters, states, lhs, inputs)
-
-        if execute_solver:
-            self.model.refit()
 
         return states
 
@@ -657,20 +654,18 @@ class _BaseROM(abc.ABC):
         )
 
         # Fit the model for the first time.
-        states_ = self._fit_and_return_training_data(
+        self._fit_solver(
             parameters=parameters,
             states=states,
             lhs=ddts,
             inputs=inputs,
             fit_transformer=fit_transformer,
             fit_basis=fit_basis,
-            execute_solver=False,
         )
 
         # Set up the regularization selection.
-        initial_conditions = [self.encode(Q[:, 0]) for Q in states]
-        states = states_
-        shifts, limits = self._get_stability_limits(states, stability_margin)
+        states_ = [self.encode(Q) for Q in states]
+        shifts, limits = self._get_stability_limits(states_, stability_margin)
 
         def unstable(_Q, ell, size):
             """Return ``True`` if the solution is unstable."""
@@ -693,13 +688,8 @@ class _BaseROM(abc.ABC):
             time_domains = train_time_domains
 
         if input_functions is None:
-            input_functions = [None] * len(states)
-        loop_collections = [
-            initial_conditions,
-            states,
-            input_functions,
-            time_domains,
-        ]
+            input_functions = [None] * len(states_)
+        loop_collections = [states_, input_functions, time_domains]
         if is_parametric := parameters is not None:
             loop_collections.insert(0, parameters)
 
@@ -729,11 +719,11 @@ class _BaseROM(abc.ABC):
             error = 0
             for ell, entries in enumerate(zip(*loop_collections)):
                 if is_parametric:
-                    params, q0, Q, input_func, t = entries
-                    predict_args = (params, q0, t, input_func)
+                    params, Q, input_func, t = entries
+                    predict_args = (params, Q[:, 0], t, input_func)
                 else:
-                    q0, Q, input_func, t = entries
-                    predict_args = (q0, t, input_func)
+                    Q, input_func, t = entries
+                    predict_args = (Q[:, 0], t, input_func)
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore")
                     solution = self.model.predict(
@@ -742,13 +732,10 @@ class _BaseROM(abc.ABC):
                 if unstable(solution, ell, t.size):
                     return np.inf
                 trainsize = Q.shape[-1]
-                solution_train = solution[:, :trainsize]
-                t_train = t[:trainsize]
-                if self.ddt_estimator is not None:
-                    solution_train = self.ddt_estimator.mask(solution_train)
-                    t_train = self.ddt_estimator.mask(t_train)
-                error += post.Lp_error(Q, solution_train, t_train)[1]
-            return error / len(states)
+                error += post.Lp_error(
+                    Q, solution[:, :trainsize], t[:trainsize]
+                )[1]
+            return error / len(states_)
 
         best_regularization = utils.gridsearch(
             training_error,
@@ -878,19 +865,18 @@ class _BaseROM(abc.ABC):
             test_cases, utils.DiscreteRegTest
         )
 
-        # Fit the model for the first time.
-        states = self._fit_and_return_training_data(
+        # Fit the model for the first time and get compressed training data.
+        states_ = self._fit_solver(
             parameters=parameters,
             states=states,
             lhs=None,
             inputs=inputs,
             fit_transformer=fit_transformer,
             fit_basis=fit_basis,
-            execute_solver=False,
         )
 
         # Set up the regularization selection.
-        shifts, limits = self._get_stability_limits(states, stability_margin)
+        shifts, limits = self._get_stability_limits(states_, stability_margin)
 
         def unstable(_Q, ell):
             """Return ``True`` if the solution is unstable."""
@@ -899,13 +885,13 @@ class _BaseROM(abc.ABC):
             return np.any(np.abs(_Q - shifts[ell]).max() > limits[ell])
 
         # Extend the iteration counts by the number of testing iterations.
-        num_iters = [Q.shape[-1] for Q in states]
+        num_iters = [Q.shape[-1] for Q in states_]
         if num_test_iters > 0:
             num_iters = [n + num_test_iters for n in num_iters]
 
         if inputs is None:
-            inputs = [None] * len(states)
-        loop_collections = [states, inputs, num_iters]
+            inputs = [None] * len(states_)
+        loop_collections = [states_, inputs, num_iters]
         if is_parametric := parameters is not None:
             loop_collections.insert(0, parameters)
 
@@ -946,7 +932,7 @@ class _BaseROM(abc.ABC):
                 if unstable(solution, ell):
                     return np.inf
                 error += post.frobenius_error(Q, solution[:, : Q.shape[-1]])[1]
-            return error / len(states)
+            return error / len(states_)
 
         best_regularization = utils.gridsearch(
             training_error,

--- a/src/opinf/roms/_base.py
+++ b/src/opinf/roms/_base.py
@@ -735,16 +735,12 @@ class _BaseROM(abc.ABC):
                 if unstable(solution, ell, t.size):
                     return np.inf
                 trainsize = Q.shape[-1]
-                solution_train = solution[:, :trainsize]
+                if self.ddt_estimator is not None:
+                    solution_train = self.ddt_estimator.mask(solution)
+                else:
+                    solution_train = solution[:, :trainsize]
                 error += post.Lp_error(Q, solution_train, t[:trainsize])[1]
             return error / len(states)
-
-        # BUG: training states may not align with the first `trainsize`
-        # entries of `solution` because `Q` (from `states`) may have been
-        # cropped by the time derivative estimator.
-        # This is not an issue for fully discrete models.
-        # Potential fix: implement some kind of mask in ddt_estimator and
-        # replace `solution[:, :trainsize]` -> `solution[:, the_ddt_mask]`.
 
         best_regularization = utils.gridsearch(
             training_error,

--- a/src/opinf/roms/_nonparametric.py
+++ b/src/opinf/roms/_nonparametric.py
@@ -106,7 +106,7 @@ class ROM(_BaseROM):
         -------
         self
         """
-        self._fit_and_return_training_data(
+        self._fit_solver(
             parameters=None,
             states=states,
             lhs=lhs,
@@ -114,6 +114,7 @@ class ROM(_BaseROM):
             fit_transformer=fit_transformer,
             fit_basis=fit_basis,
         )
+        self.model.refit()
         return self
 
     def fit_regselect_continuous(

--- a/src/opinf/roms/_parametric.py
+++ b/src/opinf/roms/_parametric.py
@@ -105,7 +105,7 @@ class ParametricROM(_BaseROM):
         -------
         self
         """
-        self._fit_and_return_training_data(
+        self._fit_solver(
             parameters=parameters,
             states=states,
             lhs=lhs,
@@ -113,6 +113,7 @@ class ParametricROM(_BaseROM):
             fit_transformer=fit_transformer,
             fit_basis=fit_basis,
         )
+        self.model.refit()
         return self
 
     # Evaluation --------------------------------------------------------------

--- a/tests/regression/test_basics.py
+++ b/tests/regression/test_basics.py
@@ -1,0 +1,112 @@
+# test_basics.py
+"""Regression test: linear heat equation, extrapolation to new initial =
+conditions.
+"""
+import os
+import pytest
+import numpy as np
+import scipy.sparse
+import scipy.integrate
+
+import opinf
+
+
+DATAFILE = f"{__file__[:-3]}-data.npz"
+
+
+def generate_data():
+    L = 1
+    n = 2**10 - 1
+    x_all = np.linspace(0, L, n + 2)
+    x = x_all[1:-1]
+    dx = x[1] - x[0]
+
+    t0, tf = 0, 1
+    k = 401
+    t = np.linspace(t0, tf, k)
+
+    diags = np.array([1, -2, 1]) / (dx**2)
+    A = scipy.sparse.diags(diags, [-1, 0, 1], (n, n))
+
+    # Initial conditions for the training data.
+    q0s = [
+        x * (1 - x),
+        10 * x * (1 - x),
+        5 * x**2 * (1 - x) ** 2,
+        50 * x**4 * (1 - x) ** 4,
+        0.5 * np.sqrt(x * (1 - x)),
+        0.25 * np.sqrt(np.sqrt(x * (1 - x))),
+        np.sin(np.pi * x) / 3 + np.sin(5 * np.pi * x) / 5,
+    ]
+
+    def full_order_solve(initial_condition, time_domain):
+        """Solve the full-order model with SciPy."""
+        return scipy.integrate.solve_ivp(
+            fun=lambda t, q: A @ q,
+            t_span=[time_domain[0], time_domain[-1]],
+            y0=initial_condition,
+            t_eval=time_domain,
+            method="BDF",
+        ).y
+
+    Qs = np.array([full_order_solve(q0, t) for q0 in q0s])
+    np.savez(DATAFILE, t=t, Qs=Qs)
+
+
+@pytest.fixture
+def data():
+    if not os.path.isfile(DATAFILE):
+        generate_data()
+    return np.load(DATAFILE)
+
+
+def test_01(data, whichinit: int = 0):
+    """OpInf ROM, reproduce training data, no extrapolation."""
+    t, Qs = data["t"], data["Qs"]
+    Q = Qs[whichinit]
+
+    rom = opinf.ROM(
+        basis=opinf.basis.PODBasis(cumulative_energy=0.9999),
+        ddt_estimator=opinf.ddt.UniformFiniteDifferencer(t, "ord6"),
+        model=opinf.models.ContinuousModel(
+            operators="A",
+            solver=opinf.lstsq.L2Solver(regularizer=1e-8),
+        ),
+    ).fit(Q)
+
+    Q_ROM = rom.predict(Q[:, 0], t, method="BDF")
+    error = opinf.post.frobenius_error(Q, Q_ROM)[1]
+    assert error < 0.00105
+
+
+def test_02(data):
+    """OpInf ROM, training data from one trajectory, basis enriched with a few
+    initial conditions.
+    """
+    t, Qs = data["t"], data["Qs"]
+    Qtrain = Qs[0]
+    q0_new = [Q[:, 0] for Q in Qs[1:]]
+
+    Q_and_new_q0s = np.column_stack((Qtrain, *q0_new))
+
+    # Initialize a ROM with the new basis.
+    rom = opinf.ROM(
+        basis=opinf.basis.PODBasis(num_vectors=5).fit(Q_and_new_q0s),
+        ddt_estimator=opinf.ddt.UniformFiniteDifferencer(t, "ord6"),
+        model=opinf.models.ContinuousModel(
+            operators="A",
+            solver=opinf.lstsq.L2Solver(regularizer=1e-8),
+        ),
+    ).fit(Qtrain, fit_basis=False)
+
+    maxerrors = [0.00041, 0.00085, 0.00335, 0.00340, 0.009500, 0.02610]
+    for Q, maxerr in zip(Qs, maxerrors):
+        Q_ROM = rom.predict(Q[:, 0], t, method="BDF")
+        error = opinf.post.frobenius_error(Q, Q_ROM)[1]
+        assert error < maxerr
+
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([__file__])

--- a/tests/regression/test_inputs.py
+++ b/tests/regression/test_inputs.py
@@ -1,0 +1,146 @@
+# test_inputs.py
+"""Heat equation with inputs."""
+import os
+import pytest
+import numpy as np
+import scipy.sparse
+
+import opinf
+
+
+DATAFILE = f"{__file__[:-3]}-data.npz"
+
+
+input_functions = [
+    lambda t: np.ones_like(t) + np.sin(4 * np.pi * t) / 4,
+    lambda t: np.exp(-t),
+    lambda t: 1 + t**2 / 2,
+    lambda t: 1 - np.sin(np.pi * t) / 2,
+    lambda t: 1 - np.sin(3 * np.pi * t) / 3,
+    lambda t: 1 + 25 * (t * (t - 1)) ** 3,
+    lambda t: 1 + np.exp(-2 * t) * np.sin(np.pi * t),
+]
+
+
+def generate_data():
+
+    # Construct the spatial domain.
+    L = 1
+    n = 2**10 - 1
+    x_all = np.linspace(0, L, n + 2)
+    x = x_all[1:-1]
+    dx = x[1] - x[0]
+
+    # Construct the temporal domain.
+    T = 1
+    K = 10**3 + 1
+    t_all = np.linspace(0, T, K)
+
+    # Construct the full-order state matrix A.
+    dx2inv = 1 / dx**2
+    diags = np.array([1, -2, 1]) * dx2inv
+    A = scipy.sparse.diags(diags, [-1, 0, 1], (n, n))
+
+    # Construct the full-order input matrix B.
+    B = np.zeros_like(x)
+    B[0], B[-1] = dx2inv, dx2inv
+
+    # Define the full-order model with an opinf.models class.
+    fom = opinf.models.ContinuousModel(
+        operators=[
+            opinf.operators.LinearOperator(A),
+            opinf.operators.InputOperator(B),
+        ]
+    )
+
+    # Construct the part of the initial condition not dependent on u(t).
+    alpha = 100
+    q0 = np.exp(alpha * (x - 1)) + np.exp(-alpha * x) - np.exp(-alpha)
+
+    def full_order_solve(time_domain, u):
+        """Solve the full-order model with SciPy.
+        Here, u is a callable function.
+        """
+        return fom.predict(q0 * u(0), time_domain, u, method="BDF")
+
+    # Solve the full-order model with the training input.
+    Qs = np.array([full_order_solve(t_all, u) for u in input_functions])
+
+    np.savez(DATAFILE, t_all=t_all, Qs=Qs, A=A.toarray(), B=B)
+
+
+@pytest.fixture
+def data():
+    if not os.path.isfile(DATAFILE):
+        generate_data()
+    return np.load(DATAFILE)
+
+
+def test_01(data, k: int = 200, whichinput: int = 0):
+    """Intrusive ROM, single trajectory, prediction in time."""
+    t_all, Qs, A, B = data["t_all"], data["Qs"], data["A"], data["B"]
+    Q = Qs[whichinput]
+    basis = opinf.basis.PODBasis(residual_energy=1e-6).fit(Q[:, :k])
+
+    rom_intrusive = opinf.ROM(
+        basis=basis,
+        model=opinf.models.ContinuousModel(
+            operators=[
+                opinf.operators.LinearOperator(A),
+                opinf.operators.InputOperator(B),
+            ]
+        ).galerkin(
+            basis.entries
+        ),  # Explicitly project FOM operators.
+    )
+    Q_ROM_intrusive = rom_intrusive.predict(
+        Q[:, 0], t_all, input_func=input_functions[whichinput], method="BDF"
+    )
+
+    error = opinf.post.frobenius_error(Q, Q_ROM_intrusive)[1]
+    assert error < 0.0009
+
+
+def test_02(data, k: int = 200, whichinput: int = 0):
+    """OpInf ROM, single trajectory, prediction in time."""
+    t_all, Qs = data["t_all"], data["Qs"]
+    t = t_all[:k]
+    Q = Qs[whichinput]
+    input_func = input_functions[whichinput]
+
+    rom = opinf.ROM(
+        basis=opinf.basis.PODBasis(residual_energy=1e-6),
+        ddt_estimator=opinf.ddt.UniformFiniteDifferencer(t, "ord6"),
+        model=opinf.models.ContinuousModel("AB"),
+    ).fit(Q[:, :k], inputs=input_func(t))
+
+    Q_ROM = rom.predict(Q[:, 0], t_all, input_func=input_func, method="BDF")
+
+    error = opinf.post.frobenius_error(Q, Q_ROM)[1]
+    assert error < 0.0009
+
+
+def test_03(data, k: int = 200, ntrain: int = 4):
+    """OpInf ROM, multiple trajectories, prediction in time"""
+    t_all, Qs = data["t_all"], data["Qs"]
+    t = t_all[:k]
+    Q_train = [Q[:, :k] for Q in Qs[:ntrain]]
+    Q_test = Qs[ntrain:]
+    U_train = [u(t) for u in input_functions[:ntrain]]
+
+    rom = opinf.ROM(
+        basis=opinf.basis.PODBasis(residual_energy=1e-6),
+        ddt_estimator=opinf.ddt.UniformFiniteDifferencer(t, "ord6"),
+        model=opinf.models.ContinuousModel("AB"),
+    ).fit(Q_train, inputs=U_train)
+
+    for i, u in enumerate(input_functions[ntrain:]):
+        Q_ROM = rom.predict(Q_test[i][:, 0], t_all, u, method="BDF")
+        error = opinf.post.frobenius_error(Q_test[i], Q_ROM)[1]
+        assert error < 0.001
+
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([__file__])

--- a/tests/regression/test_lifting.py
+++ b/tests/regression/test_lifting.py
@@ -1,0 +1,306 @@
+# test_lifting.py
+"""Regression test: Lifting, quadratic ROM, regularization selection."""
+import os
+import pytest
+import itertools
+import numpy as np
+import scipy.interpolate
+
+import opinf
+
+
+DATAFILE = f"{__file__[:-3]}-data.npz"
+
+
+v_bar = 1e2
+p_bar = 1e5
+z_bar = 1e-1
+
+
+class EulerFiniteDifferenceModel:
+    n_var = 3
+    gamma = 1.4
+
+    def __init__(self, L: float = 2.0, n_x: int = 200):
+        self.x = np.linspace(0, L, n_x + 1)[:-1]
+        self.dx = self.x[1] - self.x[0]
+        self.L = L
+
+    def spline_initial_conditions(self, init_params):
+        x, L = self.x, self.L
+        rho0s, v0s = init_params[0:3], init_params[3:6]
+        v0s = np.concatenate((v0s, [v0s[0]]))
+        rho0s = np.concatenate((rho0s, [rho0s[0]]))
+
+        nodes = np.array([0, L / 3, 2 * L / 3, L]) + x[0]
+        rho = scipy.interpolate.CubicSpline(nodes, rho0s, bc_type="periodic")(
+            x
+        )
+        v = scipy.interpolate.CubicSpline(nodes, v0s, bc_type="periodic")(x)
+        p = 1e5 * np.ones_like(x)
+        rho_e = p / (self.gamma - 1) + 0.5 * rho * v**2
+
+        return np.concatenate((rho, rho * v, rho_e))
+
+    def _ddx(self, variable):
+        return (variable - np.roll(variable, 1, axis=0)) / self.dx
+
+    def derivative(self, tt, state):
+        rho, rho_v, rho_e = np.split(state, self.n_var)
+        v = rho_v / rho
+        p = (self.gamma - 1) * (rho_e - 0.5 * rho * v**2)
+
+        return -np.concatenate(
+            [
+                self._ddx(rho_v),
+                self._ddx(rho * v**2 + p),
+                self._ddx((rho_e + p) * v),
+            ]
+        )
+
+    def solve(self, q_init, time_domain):
+        return scipy.integrate.solve_ivp(
+            fun=self.derivative,
+            t_span=[time_domain[0], time_domain[-1]],
+            y0=q_init,
+            method="RK45",
+            t_eval=time_domain,
+            rtol=1e-6,
+            atol=1e-9,
+        ).y
+
+
+# Experiment data =============================================================
+def generate_data():
+    fom = EulerFiniteDifferenceModel(L=2, n_x=200)
+
+    t_final = 0.15
+    n_t = 501
+    t_all = np.linspace(0, t_final, n_t)
+
+    t_obs = 0.06
+    t_train = t_all[t_all <= t_obs]
+
+    q0s = [
+        fom.spline_initial_conditions(icparams)
+        for icparams in itertools.product(
+            [20, 24],
+            [22],
+            [20, 24],
+            [95, 105],
+            [100],
+            [95, 105],
+        )
+    ]
+
+    Q_fom = np.array([fom.solve(q0, t_train) for q0 in q0s])
+    test_init = fom.spline_initial_conditions([22, 21, 25, 100, 98, 102])
+    test_solution = fom.solve(test_init, t_all)
+
+    np.savez(
+        DATAFILE,
+        x=fom.x,
+        t_train=t_train,
+        Qs=Q_fom,
+        t_all=t_all,
+        Qtest=test_solution,
+    )
+
+
+@pytest.fixture
+def data():
+    if not os.path.isfile(DATAFILE):
+        generate_data()
+    return np.load(DATAFILE)
+
+
+class EulerLifter(opinf.lift.LifterTemplate):
+    num_original_variables = 3
+    num_lifted_variables = 3
+
+    def lift(self, original_state):
+        rho, rho_v, rho_e = np.split(
+            original_state,
+            self.num_original_variables,
+            axis=0,
+        )
+
+        v = rho_v / rho
+        p = (EulerFiniteDifferenceModel.gamma - 1) * (
+            rho_e - 0.5 * rho_v * v
+        )  # From the ideal gas law.
+        zeta = 1 / rho
+
+        return np.concatenate((v, p, zeta))
+
+    def unlift(self, lifted_state):
+        v, p, zeta = np.split(
+            lifted_state,
+            self.num_lifted_variables,
+            axis=0,
+        )
+
+        rho = 1 / zeta
+        rho_v = rho * v
+        rho_e = (
+            p / (EulerFiniteDifferenceModel.gamma - 1) + 0.5 * rho_v * v
+        )  # From the ideal gas law.
+
+        return np.concatenate((rho, rho_v, rho_e))
+
+
+def rom_test_error(rom, maxerr: float):
+    thedata = np.load(DATAFILE)
+    t, Qtest = thedata["t_all"], thedata["Qtest"]
+
+    Qrom = rom.predict(Qtest[:, 0], t)
+    error = opinf.post.Lp_error(Qtest, Qrom, t)[1]
+
+    assert error < maxerr
+
+
+def test_01(data):
+    """Lifting, scaling, fixed regularization (no centering)."""
+    t_train, Qs = data["t_train"], data["Qs"]
+
+    rom = opinf.ROM(
+        lifter=EulerLifter(),
+        transformer=opinf.pre.TransformerMulti(
+            [
+                opinf.pre.ScaleTransformer(1 / v_bar),
+                opinf.pre.ScaleTransformer(1 / p_bar),
+                opinf.pre.ScaleTransformer(1 / z_bar),
+            ]
+        ),
+        basis=opinf.basis.PODBasis(num_vectors=9),
+        ddt_estimator=opinf.ddt.UniformFiniteDifferencer(
+            t_train, scheme="fwd4"
+        ),
+        model=opinf.models.ContinuousModel(
+            operators=[opinf.operators.QuadraticOperator()],
+            solver=opinf.lstsq.L2Solver(regularizer=1e-8),
+        ),
+    ).fit(Qs)
+
+    rom_test_error(rom, 0.0032)
+
+
+def test_02(data):
+    """Lifting, scaling, regularization selection (no centering)."""
+    t_train, Qs = data["t_train"], data["Qs"]
+
+    rom = opinf.ROM(
+        lifter=EulerLifter(),
+        transformer=opinf.pre.TransformerMulti(
+            [
+                opinf.pre.ScaleTransformer(1 / v_bar),
+                opinf.pre.ScaleTransformer(1 / p_bar),
+                opinf.pre.ScaleTransformer(1 / z_bar),
+            ]
+        ),
+        basis=opinf.basis.PODBasis(num_vectors=9),
+        ddt_estimator=opinf.ddt.UniformFiniteDifferencer(
+            t_train, scheme="fwd4"
+        ),
+        model=opinf.models.ContinuousModel(
+            operators=[opinf.operators.QuadraticOperator()],
+            solver=opinf.lstsq.L2Solver(regularizer=1e-8),
+        ),
+    ).fit_regselect_continuous(
+        candidates=np.logspace(-12, 2, 15),
+        train_time_domains=t_train,
+        states=Qs,
+        verbose=False,
+    )
+
+    rom_test_error(rom, 0.0023)
+
+
+def test_03(data):
+    """Lifting, centering, data-driven scaling, regularization selection."""
+    t_train, Qs = data["t_train"], data["Qs"]
+
+    rom = opinf.ROM(
+        lifter=EulerLifter(),
+        transformer=opinf.pre.TransformerMulti(  # Variable-specific scaling
+            [
+                opinf.pre.ShiftScaleTransformer(
+                    centering=True, scaling="minmax"
+                ),
+                opinf.pre.ShiftScaleTransformer(
+                    centering=True, scaling="minmax"
+                ),
+                opinf.pre.ShiftScaleTransformer(
+                    centering=True, scaling="minmax"
+                ),
+            ]
+        ),
+        basis=opinf.basis.PODBasis(num_vectors=9),
+        ddt_estimator=opinf.ddt.UniformFiniteDifferencer(
+            t_train, scheme="fwd4"
+        ),
+        model=opinf.models.ContinuousModel(
+            operators=[
+                opinf.operators.ConstantOperator(),  # c
+                opinf.operators.LinearOperator(),  # Aq(t)
+                opinf.operators.QuadraticOperator(),  # H[q(t) ⊗ q(t)]
+            ],
+            solver=opinf.lstsq.L2Solver(regularizer=1e-8),
+        ),
+    )
+
+    rom.fit_regselect_continuous(
+        candidates=np.logspace(-12, 2, 15),
+        train_time_domains=t_train,
+        states=Qs,
+        verbose=False,
+    )
+
+    rom_test_error(rom, 0.0031)
+
+
+def test_04(data):
+    """Lifting, centering, exact scaling, regularization selection."""
+    t_train, Qs = data["t_train"], data["Qs"]
+
+    rom = opinf.ROM(
+        lifter=EulerLifter(),
+        transformer=opinf.pre.TransformerPipeline(
+            [
+                opinf.pre.ShiftScaleTransformer(centering=True),  # Center.
+                opinf.pre.TransformerMulti(
+                    transformers=[
+                        opinf.pre.ScaleTransformer(1 / v_bar),
+                        opinf.pre.ScaleTransformer(1 / p_bar),
+                        opinf.pre.ScaleTransformer(1 / z_bar),
+                    ]
+                ),
+            ],
+        ),
+        basis=opinf.basis.PODBasis(num_vectors=8),
+        ddt_estimator=opinf.ddt.UniformFiniteDifferencer(
+            t_train, scheme="fwd4"
+        ),
+        model=opinf.models.ContinuousModel(
+            operators=[
+                opinf.operators.ConstantOperator(),
+                opinf.operators.LinearOperator(),
+                opinf.operators.QuadraticOperator(),
+            ],
+            solver=opinf.lstsq.L2Solver(regularizer=1e-8),
+        ),
+    )
+
+    rom.fit_regselect_continuous(
+        candidates=np.logspace(-12, 2, 15),
+        train_time_domains=t_train,
+        states=Qs,
+    )
+
+    rom_test_error(rom, 0.0021)
+
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([__file__])

--- a/tests/regression/test_lifting.py
+++ b/tests/regression/test_lifting.py
@@ -204,7 +204,7 @@ def test_02(data):
         ),
         model=opinf.models.ContinuousModel(
             operators=[opinf.operators.QuadraticOperator()],
-            solver=opinf.lstsq.L2Solver(regularizer=1e-8),
+            solver=opinf.lstsq.L2Solver(),
         ),
     ).fit_regselect_continuous(
         candidates=np.logspace(-12, 2, 15),
@@ -245,7 +245,7 @@ def test_03(data):
                 opinf.operators.LinearOperator(),  # Aq(t)
                 opinf.operators.QuadraticOperator(),  # H[q(t) ⊗ q(t)]
             ],
-            solver=opinf.lstsq.L2Solver(regularizer=1e-8),
+            solver=opinf.lstsq.L2Solver(),
         ),
     )
 
@@ -287,7 +287,7 @@ def test_04(data):
                 opinf.operators.LinearOperator(),
                 opinf.operators.QuadraticOperator(),
             ],
-            solver=opinf.lstsq.L2Solver(regularizer=1e-8),
+            solver=opinf.lstsq.L2Solver(),
         ),
     )
 

--- a/tests/regression/test_parametric.py
+++ b/tests/regression/test_parametric.py
@@ -1,0 +1,132 @@
+# test_parametric.py
+"""Regression test: parametric problems."""
+
+import os
+import pytest
+import numpy as np
+import scipy.sparse
+
+import opinf
+
+
+DATAFILE = f"{__file__[:-3]}-data.npz"
+
+
+def generate_data():
+    s = 10
+    training_parameters = np.logspace(-1, 1, s)
+    testing_parameters = np.sqrt(
+        training_parameters[:-1] * training_parameters[1:]
+    )
+
+    L = 1
+    n = 2**10 - 1
+    x_all = np.linspace(0, L, n + 2)
+    x = x_all[1:-1]
+    dx = x[1] - x[0]
+
+    T = 1
+    K = 401
+    t_all = np.linspace(0, T, K)
+
+    dx2inv = 1 / dx**2
+    diags = np.array([1, -2, 1]) * dx2inv
+    A0 = scipy.sparse.diags(diags, [-1, 0, 1], (n, n))
+
+    c0 = np.zeros_like(x)
+    c0[0], c0[-1] = dx2inv, dx2inv
+
+    alpha = 100
+    q0 = np.exp(alpha * (x - 1)) + np.exp(-alpha * x) - np.exp(-alpha)
+
+    def full_order_solve(mu, time_domain):
+        """Solve the full-order model with SciPy.
+        Here, u is a callable function.
+        """
+        return scipy.integrate.solve_ivp(
+            fun=lambda t, q: mu * (c0 + A0 @ q),
+            y0=q0,
+            t_span=[time_domain[0], time_domain[-1]],
+            t_eval=time_domain,
+            method="BDF",
+        ).y
+
+    Qtrain = [full_order_solve(mu, t_all) for mu in training_parameters]
+    Qtest = [full_order_solve(mu, t_all) for mu in testing_parameters]
+
+    np.savez(
+        DATAFILE,
+        t_all=t_all,
+        training_parameters=training_parameters,
+        testing_parameters=testing_parameters,
+        Qtrain=Qtrain,
+        Qtest=Qtest,
+    )
+
+
+@pytest.fixture
+def data():
+    if not os.path.isfile(DATAFILE):
+        generate_data()
+    return np.load(DATAFILE)
+
+
+def test_01(data):
+    t_all, training_parameters, testing_parameters, Qtrain, Qtest = (
+        data["t_all"],
+        data["training_parameters"],
+        data["testing_parameters"],
+        data["Qtrain"],
+        data["Qtest"],
+    )
+
+    rom = opinf.ParametricROM(
+        basis=opinf.basis.PODBasis(projection_error=1e-6),
+        ddt_estimator=opinf.ddt.UniformFiniteDifferencer(t_all, "ord6"),
+        model=opinf.models.ParametricContinuousModel(
+            operators=[
+                opinf.operators.AffineConstantOperator(1),
+                opinf.operators.AffineLinearOperator(1),
+            ],
+            solver=opinf.lstsq.L2Solver(1e-6),
+        ),
+    ).fit(training_parameters, Qtrain)
+
+    maxerrors = [
+        0.0528,
+        0.0344,
+        0.0228,
+        0.0156,
+        0.0111,
+        0.0078,
+        0.0051,
+        0.0028,
+        0.0010,
+        0.0002,
+    ]
+    for mu, Q, maxerr in zip(training_parameters, Qtrain, maxerrors):
+        Q_ROM = rom.predict(mu, Q[:, 0], t_all, method="BDF")
+        error = opinf.post.frobenius_error(Q, Q_ROM)[1]
+        assert error < maxerr
+
+    maxerrors = [
+        0.0426,
+        0.0279,
+        0.0188,
+        0.0131,
+        0.0093,
+        0.0064,
+        0.0039,
+        0.0018,
+        0.0004,
+    ]
+    for mu, Q, maxerr in zip(testing_parameters, Qtest, maxerrors):
+        Q_ROM = rom.predict(mu, Q[:, 0], t_all, method="BDF")
+        error = opinf.post.frobenius_error(Q, Q_ROM)[1]
+        assert error < maxerr
+
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([__file__])


### PR DESCRIPTION
- Improvement to `fit_regselect_*()` so that the regularization does not have to be initialized before fitting the model. This fixes a longstanding chicken/egg problem and makes using `fit_regselect_*()` much less cumbersome.
- Ensured error computation correctly aligns training and predicted states in  `fit_regselect_continuous()`. Previously, this could have been misaligned when using a time derivative estimator that truncates states.
- Time derivative estimators in `opinf.ddt` now have a `mask()` method that map states to the estimation grid.
- Added regression tests based on the tutorial notebooks.
- Added `pytest` and `pytest-cov` to the dependencies for developers.

This also bumps the version to `0.5.15`.