### PR TITLE
Regularization Selection Fixes

### DIFF
--- a/docs/literature.bib
+++ b/docs/literature.bib
@@ -666,3 +666,14 @@
     doi = {10.48550/arXiv.2504.03990},
     category = {application}
 }
+
+@article{gkimisis2025spatiallylocalized,
+    title = {Non-intrusive reduced-order modeling for dynamical systems with spatially localized features},
+    author = {Leonidas Gkimisis and Nicole Aretz and Marco Tezzele and Thomas Richter and Peter Benner and Karen E. Willcox},
+    journal = {Computer Methods in Applied Mechanics and Engineering},
+    volume = {444},
+    pages = {118115},
+    year = {2025},
+    doi = {10.1016/j.cma.2025.118115},
+    category = {method}
+}

--- a/docs/source/opinf/changelog.md
+++ b/docs/source/opinf/changelog.md
@@ -5,6 +5,17 @@
 New versions may introduce substantial new features or API adjustments.
 :::
 
+## Version 0.5.16
+
+Backend improvements to the regularization selection procedure.
+
+- `ROM.fit()` calls `ROM.model.fit()` instead of `ROM.model._fit_solver()`, which works better for inheritance.
+- `BayesianROM.fit_regselect_*()` catches errors and suppresses warnings from the least-squares solver.
+- Fixed a bug for interpolatory parametric models where `fit_regselect_*()` would only update the regularizer for the overall `model.solver`, not for each of the individual solvers for the models to be interpolated.
+- Fixed a bug related to test cases being processed before the basis was initialized.
+- Removed unnecessary abstract methods from `models.mono._base._OpInfModel`.
+- Small updates to the literature page.
+
 ## Version 0.5.15
 
 - Improvement to `fit_regselect_*()` so that the regularization does not have to be initialized before fitting the model. This fixes a longstanding chicken/egg problem and makes using `fit_regselect_*()` much less cumbersome.

--- a/src/opinf/__init__.py
+++ b/src/opinf/__init__.py
@@ -7,7 +7,7 @@ GitHub:
     https://github.com/Willcox-Research-Group/rom-operator-inference-Python3
 """
 
-__version__ = "0.5.15"
+__version__ = "0.5.16"
 
 from . import (
     basis,

--- a/src/opinf/lstsq/_base.py
+++ b/src/opinf/lstsq/_base.py
@@ -287,6 +287,10 @@ class SolverTemplate(abc.ABC):
             options[key] = None if value == "NULL" else value
         return options
 
+    def reset(self) -> None:
+        """Reset the solver by deleting data matrices."""
+        SolverTemplate.__init__(self)
+
     def copy(self):
         """Make a copy of the solver."""
         return copy.deepcopy(self)

--- a/src/opinf/lstsq/_tikhonov.py
+++ b/src/opinf/lstsq/_tikhonov.py
@@ -113,6 +113,11 @@ class _BaseRegularizedSolver(SolverTemplate):
         raise NotImplementedError  # pragma: no cover
 
     # Persistence -------------------------------------------------------------
+    def reset(self) -> None:
+        """Reset the solver by deleting data matrices and the regularizer."""
+        super().reset()
+        self.regularizer = None
+
     def _save(self, savefile, overwrite=False, extras=tuple()):
         """Serialize the solver, saving it in HDF5 format.
         The model can be recovered with the :meth:`_load()` class method.

--- a/src/opinf/models/mono/_base.py
+++ b/src/opinf/models/mono/_base.py
@@ -391,31 +391,6 @@ class _OpInfModel(_Model):
 
     # Fitting -----------------------------------------------------------------
     @abc.abstractmethod
-    def _process_fit_arguments(self, *args, **kwargs):
-        """Prepare training data, validate and set dimensions, etc."""
-        pass
-
-    @abc.abstractmethod
-    def _assemble_data_matrix(self, *args, **kwargs):
-        """Construct the Operator Inference data matrix."""
-        pass
-
-    @abc.abstractmethod
-    def _extract_operators(self, *args, **kwargs):
-        """Unpack the Operator Inference solution, the operator matrix."""
-        pass
-
-    @abc.abstractmethod
-    def _fit_solver(self, *args, **kwargs):
-        """Initialize the regression solver."""
-        pass
-
-    @abc.abstractmethod
-    def refit(self, *args, **kwargs):
-        """Solve the regression and unpack the results."""
-        pass
-
-    @abc.abstractmethod
-    def fit(self, *args, **kwargs):
+    def fit(self, *args, **kwargs):  # pragma: no cover
         """Learn model operators from data."""
         pass

--- a/src/opinf/roms/_base.py
+++ b/src/opinf/roms/_base.py
@@ -668,6 +668,11 @@ class _BaseROM(abc.ABC):
         if regularizer_factory is None:
             regularizer_factory = _identity
 
+        # Reset the solver (in case the basis dimension changed between calls).
+        interp = modutils.is_interpolatory(self.model)
+        if hasattr(self.model, "reset"):
+            self.model.solver.reset()
+
         # Fit the model for the first time.
         self._fit_model(
             parameters=parameters,
@@ -714,7 +719,12 @@ class _BaseROM(abc.ABC):
 
         def update_model(reg_params):
             """Reset the regularizer and refit the model operators."""
-            self.model.solver.regularizer = regularizer_factory(reg_params)
+            reg = regularizer_factory(reg_params)
+            if interp:
+                for solver in self.model.solvers:
+                    solver.regularizer = reg
+            else:
+                self.model.solver.regularizer = reg
             self.model.refit()
 
         def training_error(reg_params):
@@ -881,6 +891,11 @@ class _BaseROM(abc.ABC):
         if regularizer_factory is None:
             regularizer_factory = _identity
 
+        # Reset the solver (in case the basis dimension changed between calls).
+        interp = modutils.is_interpolatory(self.model)
+        if hasattr(self.model, "reset"):
+            self.model.solver.reset()
+
         # Fit the model for the first time and get compressed training data.
         states_ = self._fit_model(
             parameters=parameters,
@@ -917,7 +932,12 @@ class _BaseROM(abc.ABC):
 
         def update_model(reg_params):
             """Reset the regularizer and refit the model operators."""
-            self.model.solver.regularizer = regularizer_factory(reg_params)
+            reg = regularizer_factory(reg_params)
+            if interp:
+                for solver in self.model.solvers:
+                    solver.regularizer = reg
+            else:
+                self.model.solver.regularizer = reg
             self.model.refit()
 
         def training_error(reg_params):

--- a/src/opinf/roms/_bayes.py
+++ b/src/opinf/roms/_bayes.py
@@ -293,6 +293,8 @@ class _BayesianROMMixin:
             regularizer_factory = _identity
 
         # Fit the model for the first time.
+        if hasattr(self.model.solver, "reset"):
+            self.model.solver.reset()
         self._fit_model(
             parameters=parameters,
             states=states,
@@ -443,6 +445,8 @@ class _BayesianROMMixin:
             regularizer_factory = _identity
 
         # Fit the model for the first time.
+        if hasattr(self.model.solver, "reset"):
+            self.model.solver.reset()
         states_ = self._fit_model(
             parameters=parameters,
             states=states,

--- a/src/opinf/roms/_bayes.py
+++ b/src/opinf/roms/_bayes.py
@@ -8,7 +8,6 @@ __all__ = [
 
 import warnings
 import numpy as np
-import scipy.linalg
 import scipy.stats
 
 from .. import errors, lstsq, post, utils
@@ -292,23 +291,24 @@ class _BayesianROMMixin:
             raise ValueError("argument 'test_time_length' must be nonnegative")
         if regularizer_factory is None:
             regularizer_factory = _identity
-        processed_test_cases = self._process_test_cases(
-            test_cases, utils.ContinuousRegTest
-        )
 
         # Fit the model for the first time.
-        self._fit_solver(
+        self._fit_model(
             parameters=parameters,
             states=states,
             lhs=ddts,
             inputs=inputs,
             fit_transformer=fit_transformer,
             fit_basis=fit_basis,
+            solver_only=True,
         )
 
         # Set up the regularization selection.
         states_ = [self.encode(Q) for Q in states]
         shifts, limits = self._get_stability_limits(states_, stability_margin)
+        processed_test_cases = self._process_test_cases(
+            test_cases, utils.ContinuousRegTest
+        )
 
         def unstable(_Q, ell, size):
             """Return ``True`` if the solution is unstable."""
@@ -439,22 +439,23 @@ class _BayesianROMMixin:
                     )
         if regularizer_factory is None:
             regularizer_factory = _identity
-        processed_test_cases = self._process_test_cases(
-            test_cases, utils.DiscreteRegTest
-        )
 
         # Fit the model for the first time.
-        states_ = self._fit_solver(
+        states_ = self._fit_model(
             parameters=parameters,
             states=states,
             lhs=None,
             inputs=inputs,
             fit_transformer=fit_transformer,
             fit_basis=fit_basis,
+            solver_only=True,
         )
 
         # Set up the regularization selection.
         shifts, limits = self._get_stability_limits(states_, stability_margin)
+        processed_test_cases = self._process_test_cases(
+            test_cases, utils.DiscreteRegTest
+        )
 
         def unstable(_Q, ell):
             """Return ``True`` if the solution is unstable."""

--- a/src/opinf/roms/_nonparametric.py
+++ b/src/opinf/roms/_nonparametric.py
@@ -106,15 +106,15 @@ class ROM(_BaseROM):
         -------
         self
         """
-        self._fit_solver(
+        self._fit_model(
             parameters=None,
             states=states,
             lhs=lhs,
             inputs=inputs,
             fit_transformer=fit_transformer,
             fit_basis=fit_basis,
+            solver_only=False,
         )
-        self.model.refit()
         return self
 
     def fit_regselect_continuous(

--- a/src/opinf/roms/_parametric.py
+++ b/src/opinf/roms/_parametric.py
@@ -105,15 +105,15 @@ class ParametricROM(_BaseROM):
         -------
         self
         """
-        self._fit_solver(
+        self._fit_model(
             parameters=parameters,
             states=states,
             lhs=lhs,
             inputs=inputs,
             fit_transformer=fit_transformer,
             fit_basis=fit_basis,
+            solver_only=False,
         )
-        self.model.refit()
         return self
 
     # Evaluation --------------------------------------------------------------

--- a/tests/lstsq/test_base.py
+++ b/tests/lstsq/test_base.py
@@ -179,14 +179,17 @@ class _TestSolverTemplate(abc.ABC):
                 assert residual.shape == (1,)
                 assert np.isclose(residual[0], la.norm(D @ ohat - z) ** 2)
 
-    def test_save_load_and_copy_via_verify(self, k=20, d=11, r=6):
-        """Use verify() to test save(), load(), and copy()."""
+    def test_save_load_copy_and_reset(self, k=20, d=11, r=6):
+        """Use verify() to test save(), load(), copy(); test reset()."""
         D = np.random.random((k, d))
         Z = np.random.random((r, k))
 
         for solver in self.get_solvers():
             solver.fit(D, Z)
             solver.verify()
+            solver.reset()
+            assert solver.data_matrix is None
+            assert solver.lhs_matrix is None
 
 
 class TestPlainSolver(_TestSolverTemplate):

--- a/tests/lstsq/test_tikhonov.py
+++ b/tests/lstsq/test_tikhonov.py
@@ -57,6 +57,17 @@ class _TestBaseRegularizedSolver(_TestSolverTemplate):
             "zero residual --> posterior is deterministic"
         )
 
+    def test_save_load_copy_and_reset(self, k=20, d=11, r=6):
+        D = np.random.random((k, d))
+        Z = np.random.random((r, k))
+
+        for solver in self.get_solvers():
+            solver.fit(D, Z)
+            solver.reset()
+            assert solver.regularizer is None
+
+        return super().test_save_load_copy_and_reset(k, d, r)
+
 
 class TestL2Solver(_TestBaseRegularizedSolver):
     """Test lstsq._tikhonov.L2Solver."""
@@ -393,8 +404,8 @@ class TestL2DecoupledSolver(_TestBaseRegularizedSolver):
             solver.regresidual(None)
         assert ex.value.args[0] == "solver regularizer not set"
 
-    def test_save_load_and_copy_via_verify(self, k=20, d=11):
-        return super().test_save_load_and_copy_via_verify(k, d, 4)
+    def test_save_load_copy_and_reset(self, k=20, d=11):
+        return super().test_save_load_copy_and_reset(k, d, 4)
 
 
 class TestTikhonovSolver(_TestBaseRegularizedSolver):
@@ -700,8 +711,8 @@ class TestTikhonovSolver(_TestBaseRegularizedSolver):
             solver.regresidual(None)
         assert ex.value.args[0] == "solver regularizer not set"
 
-    def test_save_load_and_copy_via_verify(self, k=20, r=6):
-        return super().test_save_load_and_copy_via_verify(k=k, d=10, r=r)
+    def test_save_load_copy_and_reset(self, k=20, r=6):
+        return super().test_save_load_copy_and_reset(k=k, d=10, r=r)
 
 
 class TestTikhonovDecoupledSolver(_TestBaseRegularizedSolver):
@@ -879,8 +890,8 @@ class TestTikhonovDecoupledSolver(_TestBaseRegularizedSolver):
             solver.regresidual(None)
         assert ex.value.args[0] == "solver regularizer not set"
 
-    def test_save_load_and_copy_via_verify(self, k=20):
-        return super().test_save_load_and_copy_via_verify(k=k, d=10, r=5)
+    def test_save_load_copy_and_reset(self, k=20):
+        return super().test_save_load_copy_and_reset(k=k, d=10, r=5)
 
 
 if __name__ == "__main__":

--- a/tests/roms/test_parametric.py
+++ b/tests/roms/test_parametric.py
@@ -274,7 +274,7 @@ class TestParametricROM(_TestBaseROM):
             rom = self.ROM(
                 model.__class__(
                     operators=model.operators,
-                    solver=opinf.lstsq.L2Solver(1e-2),
+                    solver=opinf.lstsq.L2Solver(),
                 )
             )
 


### PR DESCRIPTION
Backend improvements to the regularization selection procedure.

- `ROM.fit()` calls `ROM.model.fit()` instead of `ROM.model._fit_solver()`, which works better for inheritance.
- `BayesianROM.fit_regselect_*()` catches errors and suppresses warnings from the least-squares solver.
- **Fixed a bug** for interpolatory parametric models where `fit_regselect_*()` would only update the regularizer for the overall `model.solver`, not for each of the individual solvers for the models to be interpolated.
- **Fixed a bug** related to test cases being processed before the basis was initialized.
- Removed unnecessary abstract methods from `models.mono._base._OpInfModel`.
- Small updates to the literature page.