### PR TITLE
Basis Backend Maintenance

### DIFF
--- a/src/opinf/basis/_base.py
+++ b/src/opinf/basis/_base.py
@@ -6,6 +6,7 @@ __all__ = [
 ]
 
 import abc
+import copy
 import numpy as np
 import scipy.linalg as la
 
@@ -221,8 +222,12 @@ class BasisTemplate(abc.ABC):
         """Load a transformer from an HDF5 file."""
         raise NotImplementedError("use pickle/joblib")  # pragma: no cover
 
+    def copy(self):
+        """Make a copy of the basis."""
+        return copy.deepcopy(self)
+
     # Verification ------------------------------------------------------------
-    def verify(self):
+    def verify(self):  # pragma: no cover
         """Verify that :meth:`compress()` and :meth:`decompress()` are
         consistent in the sense that the range of :meth:`decompress()` is in
         the domain of :meth:`compress()` and that :meth:`project()` defines
@@ -266,7 +271,9 @@ class BasisTemplate(abc.ABC):
             )
         print("compress() and decompress() are consistent")
 
-    def _verify_locs(self, states_compressed, states_projected):
+    def _verify_locs(
+        self, states_compressed, states_projected
+    ):  # pragma: no cover
         """Verification of decompress() with locs != None."""
         n = states_projected.shape[0]
         locs = np.sort(np.random.choice(n, size=(n // 3), replace=False))

--- a/src/opinf/basis/_base.py
+++ b/src/opinf/basis/_base.py
@@ -102,13 +102,14 @@ class BasisTemplate(abc.ABC):
         Parameters
         ----------
         states : (n, ...) ndarray
-            Matrix of `n`-dimensional state vectors, or a single state vector.
+            Matrix of :math:`n`-dimensional state vectors, or a single state
+            vector.
 
         Returns
         -------
         states_compressed : (r, ...) ndarray
-            Matrix of `r`-dimensional latent coordinate vectors, or a single
-            coordinate vector.
+            Matrix of :math:`r`-dimensional latent coordinate vectors, or a
+            single coordinate vector.
         """
         raise NotImplementedError  # pragma: no cover
 
@@ -119,8 +120,8 @@ class BasisTemplate(abc.ABC):
         Parameters
         ----------
         states_compressed : (r, ...) ndarray
-            Matrix of `r`-dimensional latent coordinate vectors, or a single
-            coordinate vector.
+            Matrix of :math:`r`-dimensional latent coordinate vectors, or a
+            single coordinate vector.
         locs : slice or (p,) ndarray of integers or None
             If given, return the decompressed state at *only* the
             `p` specified locations (indices) described by ``locs``.
@@ -128,10 +129,27 @@ class BasisTemplate(abc.ABC):
         Returns
         -------
         states_decompressed : (n, ...) or (p, ...) ndarray
-            Matrix of `n`-dimensional decompressed state vectors, or the `p`
-            entries of such at the entries specified by ``locs``.
+            Matrix of :math:`n`-dimensional decompressed state vectors, or the
+            :math:`p` entries of such at the entries specified by ``locs``.
         """
         raise NotImplementedError  # pragma: no cover
+
+    def fit_compress(self, states):
+        """Construct the basis and map high-dimensional states to
+        low-dimensional latent coordinates.
+
+        Parameters
+        ----------
+        states : (n, k) ndarray
+            Matrix of :math:`k` :math:`n`-dimensional snapshots.
+
+        Returns
+        -------
+        states_compressed : (r, k) ndarray
+            Matrix of :math:`r`-dimensional latent coordinate vectors.
+        """
+        self.fit(states)
+        return self.compress(states)
 
     # Projection --------------------------------------------------------------
     def project(self, state):
@@ -150,13 +168,14 @@ class BasisTemplate(abc.ABC):
         Parameters
         ----------
         states : (n, ...) ndarray
-            Matrix of `n`-dimensional state vectors, or a single state vector.
+            Matrix of :math:`n`-dimensional state vectors, or a single state
+            vector.
 
         Returns
         -------
         state_projected : (n, ...) ndarray
-            Matrix of `n`-dimensional projected state vectors, or a single
-            projected state vector.
+            Matrix of :math:`n`-dimensional projected state vectors, or a
+            single projected state vector.
         """
         return self.decompress(self.compress(state))
 

--- a/src/opinf/basis/_pod.py
+++ b/src/opinf/basis/_pod.py
@@ -293,6 +293,14 @@ class PODBasis(LinearBasis):
             if weights.ndim == 1:
                 self.__sqrt_weights = np.sqrt(weights)
             else:  # (weights.ndim == 2, checked by LinearBasis)
+                if sparse.issparse(weights):
+                    weights = weights.toarray()
+                if weights.shape[0] > 100:  # pragma: no cover
+                    warnings.warn(
+                        "computing the square root of a large weight matrix, "
+                        "consider using svdsolver='method-of-snapshots'",
+                        errors.OpInfWarning,
+                    )
                 self.__sqrt_weights = la.sqrtm(weights)
                 self.__sqrt_weights_cho = la.cho_factor(self.__sqrt_weights)
 

--- a/src/opinf/ddt/_base.py
+++ b/src/opinf/ddt/_base.py
@@ -174,7 +174,7 @@ class DerivativeEstimatorTemplate(abc.ABC):
         raise NotImplementedError  # pragma: no cover
 
     # Verification ------------------------------------------------------------
-    def verify_shapes(self, r: int = 5, m: int = 3):
+    def verify_shapes(self, r: int = 5, m: int = 3):  # pragma: no cover
         """Verify that :meth:`estimate()` is consistent in the sense that the
         all outputs have the same number of columns. This method does **not**
         check the accuracy of the derivative estimation.

--- a/src/opinf/lstsq/_base.py
+++ b/src/opinf/lstsq/_base.py
@@ -296,7 +296,7 @@ class SolverTemplate(abc.ABC):
         return copy.deepcopy(self)
 
     # Verification ------------------------------------------------------------
-    def verify(self):
+    def verify(self):  # pragma: no cover
         """Verify the solver.
 
         If the solver is already trained, check :meth:`solve()`,

--- a/src/opinf/operators/_base.py
+++ b/src/opinf/operators/_base.py
@@ -230,7 +230,7 @@ class OperatorTemplate(abc.ABC):
         k: int = 10,
         fdifftol: float = 1e-5,
         ntests: int = 4,
-    ) -> None:
+    ) -> None:  # pragma: no cover
         """Verify consistency between dimension properties and required
         methods.
 
@@ -827,7 +827,7 @@ class OpInfOperator(OperatorTemplate):
         ntests: int = 4,
         r: int = 6,
         m: int = 3,
-    ) -> None:
+    ) -> None:  # pragma: no cover
         """Verify consistency between dimension properties and required
         methods.
 

--- a/src/opinf/pre/_base.py
+++ b/src/opinf/pre/_base.py
@@ -229,7 +229,7 @@ class TransformerTemplate(abc.ABC):
         raise NotImplementedError("use pickle/joblib")  # pragma: no cover
 
     # Verification ------------------------------------------------------------
-    def verify(self, tol: float = 1e-4):
+    def verify(self, tol: float = 1e-4):  # pragma: no cover
         r"""Verify that :meth:`transform()` and :meth:`inverse_transform()`
         are consistent and that :meth:`transform_ddts()`, if implemented,
         is consistent with :meth:`transform()`.
@@ -333,7 +333,7 @@ class TransformerTemplate(abc.ABC):
             )
         print("transform() and transform_ddts() are consistent")
 
-    def _verify_locs(self, states, states_transformed):
+    def _verify_locs(self, states, states_transformed):  # pragma: no cover
         """Verification for inverse_transform() with locs != None"""
         n = states.shape[0]
         locs = np.sort(np.random.choice(n, size=(n // 3), replace=False))

--- a/src/opinf/roms/_base.py
+++ b/src/opinf/roms/_base.py
@@ -735,7 +735,7 @@ class _BaseROM(abc.ABC):
             """
             try:
                 update_model(reg_params)
-            except Exception as ex:
+            except Exception as ex:  # pragma: no cover
                 if verbose:
                     print(f"{type(ex).__name__} in refit(): {ex}")
                 return np.inf
@@ -948,7 +948,7 @@ class _BaseROM(abc.ABC):
             """
             try:
                 update_model(reg_params)
-            except Exception as ex:
+            except Exception as ex:  # pragma: no cover
                 if verbose:
                     print(f"{type(ex).__name__} in refit(): {ex}")
                 return np.inf

--- a/src/opinf/roms/_base.py
+++ b/src/opinf/roms/_base.py
@@ -404,6 +404,7 @@ class _BaseROM(abc.ABC):
         # Dimensionality reduction.
         if self.basis is not None:
             if fit_basis:
+                # NOTE: self.basis.fit_compress() here?
                 self.basis.fit(np.hstack(states))
             states = [self.basis.compress(Q) for Q in states]
             if lhs is not None:

--- a/src/opinf/utils/_timer.py
+++ b/src/opinf/utils/_timer.py
@@ -139,7 +139,7 @@ class TimedBlock:
             sys.stdout = self.__new_buffer = io.StringIO()
         if self.verbose:
             print(f"{self.message}...", end=self.__front, flush=True)
-        self._tic = time.time()
+        self._tic = time.process_time()
         if self.timelimit is not None:
             signal.signal(signal.SIGALRM, self._signal_handler)
             signal.alarm(self.timelimit)
@@ -147,7 +147,7 @@ class TimedBlock:
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         """Calculate and report the elapsed time."""
-        self._toc = time.time()
+        self._toc = time.process_time()
         if self.timelimit is not None:
             signal.alarm(0)
         elapsed = self._toc - self._tic
@@ -170,7 +170,7 @@ class TimedBlock:
                 self._reset_stdout()
             raise
         else:  # If no exception, report execution time.
-            if self.verbose:
+            if self.verbose and self.message:
                 print(f"done in {elapsed:.2f} s.", flush=True, end=self.__back)
             logging.info(f"{self.message}...done in {elapsed:.6f} s.")
         self.__elapsed = elapsed

--- a/tests/basis/test_base.py
+++ b/tests/basis/test_base.py
@@ -1,178 +1,62 @@
 # basis/test_base.py
 """Tests for basis._base."""
 
+import abc
 import pytest
+import numpy as np
 
-import opinf
 
+class _TestBasisTemplate(abc.ABC):
+    """Base class for tests of classes inheriting from BasisTemplate."""
 
-class TestBaseBasis:
-    """Test basis._base.BasisTemplate."""
+    Basis = NotImplemented  # Class to test.
 
-    class Dummy(opinf.basis.BasisTemplate):
-        """Instantiable version of BasisTemplate."""
+    @abc.abstractmethod
+    def get_bases(self):
+        """Yield (untrained) basis objects to test.
 
-        def fit(self):
-            pass
+        Yields
+        ------
+        basis : opinf.Basis object
+            Initialized basis object.
+        n : int
+            Expected basis.full_state_dimension.
+        """
+        raise NotImplementedError
 
-        def compress(self, states):
-            return states + 2
+    def test_all(self, k=20):
+        """Call fit() and use verify() to test compress(), decompress(),
+        and project(). Also lightly test __str__(), __repr__(),
+        projection_error(), and fit_compress().
+        """
+        for basis, n in self.get_bases():
+            Q = np.random.standard_normal((n, k))
+            repr(basis)
 
-        def decompress(self, states, locs=None):
-            return states - 1
+            assert basis.fit(Q) is basis, "fit() should return self"
+            assert isinstance(basis.full_state_dimension, int)
+            assert basis.full_state_dimension == n
+            assert isinstance(basis.reduced_state_dimension, int)
 
-    def test_state_dimensions(self):
-        """Test BasisTemplate.__init__(), name, and dimension properties."""
-        basis = self.Dummy("thename")
-        assert basis.full_state_dimension is None
-        assert basis.reduced_state_dimension is None
-        assert basis.name == "thename"
-        basis.name = "newname"
-        assert basis.name == "newname"
+            basis.name = "varname"
+            assert "varname" in str(basis)
 
-        basis.full_state_dimension = 10.0
-        n = basis.full_state_dimension
-        assert isinstance(n, int)
-        assert basis.full_state_dimension == n
-
-        basis.reduced_state_dimension = 4.0
-        r = basis.reduced_state_dimension
-        assert isinstance(r, int)
-        assert basis.reduced_state_dimension == r
-        assert basis.shape == (n, r)
-
-        basis.full_state_dimension = None
-        assert basis.full_state_dimension is None
-
-        basis.reduced_state_dimension = None
-        assert basis.reduced_state_dimension is None
-
-    def test_str(self):
-        """Lightly test __str__() and __repr__()."""
-
-        basis = self.Dummy()
-        str(basis)
-
-        basis.full_state_dimension = 10
-        str(basis)
-
-        basis.name = "varname"
-        basis.reduced_state_dimension = 5
-        assert repr(basis).count(str(basis)) == 1
-
-    def test_project(self, q=5):
-        """Test BasisTemplate.project() and projection_error()."""
-        basis = self.Dummy()
-        assert basis.project(q) == (q + 1)
-        assert basis.projection_error(q, relative=False) == 1
-        assert basis.projection_error(q, relative=True) == 1 / q
-
-    def test_verify(self, n=20, k=21):
-        """Test BasisTemplate.verify()."""
-
-        dummy = self.Dummy()
-
-        with pytest.raises(AttributeError) as ex:
-            dummy.verify()
-        assert ex.value.args[0] == "basis not trained, call fit()"
-
-        class Dummy1(self.Dummy):
-            def __init__(self, name=None):
-                super().__init__(name)
-                self.full_state_dimension = 20
-                self.reduced_state_dimension = 5
-
-        class Dummy2a(Dummy1):
-            def compress(self, states):
-                return states[:, :-1]
-
-        class Dummy2b(Dummy1):
-            def compress(self, states):
-                if states.ndim == 1:
-                    return 0
-                return states
-
-        basis = Dummy2a()
-        with pytest.raises(opinf.errors.VerificationError) as ex:
+            # Test compress(), decompress(), and project().
             basis.verify()
-        assert ex.value.args[0] == (
-            "compress(states).shape[1] != states.shape[1]"
-        )
 
-        basis = Dummy2b()
-        with pytest.raises(opinf.errors.VerificationError) as ex:
-            basis.verify()
-        assert ex.value.args[0] == "compress(single_state_vector).ndim != 1"
+            # Test fit_compress()
+            Q1_ = basis.fit(Q).compress(Q)
+            Q2_ = basis.fit_compress(Q)
+            assert isinstance(Q1_, np.ndarray)
+            assert isinstance(Q2_, np.ndarray)
+            assert Q1_.shape == Q2_.shape
+            assert np.allclose(Q1_, Q2_)
 
-        class Dummy3a(Dummy1):
-            def decompress(self, states, locs=None):
-                return states[:-1, 1:]
+            # Test projection_error
+            assert isinstance(basis.projection_error(Q, relative=False), float)
+            assert isinstance(basis.projection_error(Q, relative=True), float)
 
-        class Dummy3b(Dummy1):
-            def decompress(self, states, locs=None):
-                if states.ndim == 1:
-                    return 100
-                return states
-
-        basis = Dummy3a()
-        with pytest.raises(opinf.errors.VerificationError) as ex:
-            basis.verify()
-        assert ex.value.args[0] == (
-            "decompress(compress(states)).shape != states.shape"
-        )
-
-        basis = Dummy3b()
-        with pytest.raises(opinf.errors.VerificationError) as ex:
-            basis.verify()
-        assert ex.value.args[0] == (
-            "decompress(compress(single_state_vector)).ndim != 1"
-        )
-
-        class Dummy4a(Dummy1):
-            pass
-
-        class Dummy4b(Dummy1):
-            def decompress(self, states, locs=None):
-                if locs is not None:
-                    return states[locs] + 1
-                return states
-
-        basis = Dummy4a()
-        with pytest.raises(opinf.errors.VerificationError) as ex:
-            basis.verify()
-        assert ex.value.args[0] == (
-            "decompress(states_compressed, locs).shape "
-            "!= decompress(states_compressed)[locs].shape"
-        )
-
-        basis = Dummy4b()
-        with pytest.raises(opinf.errors.VerificationError) as ex:
-            basis.verify()
-        assert ex.value.args[0] == (
-            "decompress(states_compressed, locs) "
-            "!= decompress(states_compressed)[locs]"
-        )
-
-        class Dummy5a(Dummy1):
-            def compress(self, states):
-                return states
-
-            def decompress(self, states, locs=None):
-                return (states if locs is None else states[locs]) + 1
-
-        class Dummy5b(Dummy5a):
-            def compress(self, states):
-                return states - 1
-
-        basis = Dummy5a()
-        with pytest.raises(opinf.errors.VerificationError) as ex:
-            basis.verify()
-        assert ex.value.args[0] == (
-            "project(project(states)) != project(states)"
-        )
-
-        basis = Dummy5b()
-        basis.verify()
+            assert isinstance(basis.copy(), type(basis))
 
 
 if __name__ == "__main__":

--- a/tests/basis/test_pod.py
+++ b/tests/basis/test_pod.py
@@ -9,6 +9,11 @@ from matplotlib import pyplot as plt
 
 import opinf
 
+try:
+    from .test_base import _TestBasisTemplate
+except ImportError:
+    from test_base import _TestBasisTemplate
+
 
 def _spd(n):
     """Generate a random symmetric postive definite nxn matrix."""
@@ -44,10 +49,42 @@ def test_Wmult(n=10):
     assert ex.value.args[0] == "expected one- or two-dimensional array"
 
 
-class TestPODBasis:
+class TestPODBasis(_TestBasisTemplate):
     """Test basis._pod.PODBasis."""
 
+    # Setup -------------------------------------------------------------------
     Basis = opinf.basis.PODBasis
+
+    def get_bases(self):
+        yield self.Basis(
+            num_vectors=5,
+            max_vectors=10,
+            svdsolver="dense",
+        ), 20
+
+        w = np.random.random(30) + 0.1
+        yield self.Basis(
+            residual_energy=1e-3,
+            svdsolver="dense",
+            weights=w,
+        ), 30
+
+        yield self.Basis(
+            svdval_threshold=1e-3,
+            svdsolver="method-of-snapshots",
+        ), 400
+
+        n = 200
+        SP = np.random.random((n, n))
+        SP = SP.T @ SP
+        SP = np.eye(n) + SP / la.norm(SP)
+        yield self.Basis(
+            num_vectors=6,
+            max_vectors=8,
+            svdsolver="eigh",
+            weights=SP,
+            minthresh=1e-20,
+        ), 200
 
     # Constructors ------------------------------------------------------------
     def test_init(self):

--- a/tests/basis/test_pod.py
+++ b/tests/basis/test_pod.py
@@ -4,8 +4,9 @@
 import os
 import pytest
 import numpy as np
-from scipy import linalg as la
-from matplotlib import pyplot as plt
+import scipy.linalg as la
+import scipy.sparse as sparse
+import matplotlib.pyplot as plt
 
 import opinf
 
@@ -85,6 +86,15 @@ class TestPODBasis(_TestBasisTemplate):
             weights=SP,
             minthresh=1e-20,
         ), 200
+
+        n = 50
+        SP = sparse.eye_array(50)
+        yield self.Basis(
+            num_vectors=5,
+            max_vectors=9,
+            svdsolver="dense",
+            weights=SP,
+        ), 50
 
     # Constructors ------------------------------------------------------------
     def test_init(self):

--- a/tests/lstsq/test_base.py
+++ b/tests/lstsq/test_base.py
@@ -102,6 +102,8 @@ class _TestSolverTemplate(abc.ABC):
                 assert solver.r == 1
                 assert np.all(solver.lhs_matrix[0, :] == Z[0])
 
+            assert isinstance(solver.copy(), type(solver))
+
     @abc.abstractmethod
     def test_solve(self):
         """Test solve()."""


### PR DESCRIPTION
Miscellaneous backend updates, mostly in the `basis` submodule.

- Added a `fit_compress()` method to the BasisTemplate that fits, then compresses.
- Updated unit test structure for basis classes.
- `PODBasis` now raises warning if a large weight matrix is given and the matrix square root is required.
- Bugfix: `PODBasis` used to crash if a `scipy.sparse` weight matrix was given and `svdsolver != 'method-of-snapshots'`, fixed now.
- Added a few `# pragma: no cover` to `verify()` methods that are actually tests, not code to be tested.